### PR TITLE
cardiff: Fixing gnuplot header

### DIFF
--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -302,7 +302,7 @@ def do_plot(current_dir, gpm_dir, main_title, subtitle, name, unit, titles,
                              (expected_value, expected_value))
             myfile.write("\n")
 
-        f.write("call \'%s/graph2D.gpm\' \'%s' \'%s\' \'%s\' \'%s\' \'%s\' "
+        f.write("call \'%s/graph2D.gpm\' \"%s" \"%s\" \'%s\' \'%s\' \'%s\' "
                 "\'%s\'\n" % (current_dir, main_title, subtitle,
                               current_dir + "/" + name + ".plot",
                               name, current_dir + name, unit))


### PR DESCRIPTION
Since commit 84cb10a5c96a6ed03bd39141a455c733e0932cbc, the gnuplot call
was avoiding the "\n" to be expanded properly.

This patch does insure the \n to be expanded making the gnuplot header
readable again.