### PR TITLE
detect: Don't keep the tun or tap interfaces

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -525,6 +525,8 @@ def detect_system(hw_lst, output=None):
         for elt in xml.findall(".//node[@class='network']"):
             name = elt.find('logicalname')
             if name is not None:
+                if name.text.startswith("tap") or name.text.startswith("tun"):
+                    break;
                 find_element(elt, 'businfo', 'businfo', name.text, 'network')
                 find_element(elt, 'vendor', 'vendor', name.text, 'network')
                 find_element(elt, 'product', 'product', name.text, 'network')


### PR DESCRIPTION
On a cloud system we could have lots of tun or tap interfaces making the
output pretty unreadble and impossible to compare.

This patch aims at preventing collecting information from tun or tap
interfaces.