### PR TITLE
cardiff: Comparing hardware physical disks

### DIFF
--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -102,7 +102,9 @@ def group_systems(global_params, bench_values, unique_id,
                   systems_groups, ignore_list):
     for name, func, title in (
             ('hpa', check.hpa, "HPA Controller"),
+            ('disk', check.physical_hpa_disks, "HPA Disks"),
             ('megaraid', check.megaraid, "Megaraid Controller"),
+            ('disk', check.physical_hpa_disks, "Megaraid Disks"),
             ('ahci', check.ahci, "AHCI Controller"),
             ('ipmi', check.ipmi, "IPMI SDR"),
             ('system', check.systems, "System"),

--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -74,7 +74,8 @@ def physical_hpa_disks(system_list, unique_id):
 
 def physical_megaraid_disks(system_list, unique_id):
     sets = search_item(system_list, unique_id, "pdisk", r"disk(\d+)",
-                       ['Wwn', 'SasAddress', 'DriveTemperature'])
+                       ['Wwn', 'SasAddress', 'DriveTemperature',
+                        'InquiryData[2]', 'DeviceId'])
     return compare_sets.compare(sets)
 
 


### PR DESCRIPTION
Just discovered that no code was calling the hardware physical disks
comparaison while it's one of the key component on a server.

This patch is simply making the proper call to get hpa & megacli PD
reporting.

It also add a couple of unique IDs that are reported by the controller
but that should not be taken in consideration when comparing the
physical disks (PDs).