### PR TITLE
Cardiff grouping fix

### DIFF
--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -71,18 +71,18 @@ $ cardiff.py -r '/var/lib/edeploy/health/dahc/cpu_load/2014_09_15-12h17'
 ''')
 
 
-def compare_disks(global_params, bench_values, unique_id, systems_groups):
+def compare_disks(bench_values, unique_id, systems_groups):
     systems = utils.find_sub_element(bench_values, unique_id, 'pdisk')
-    groups = check.physical_megaraid_disks(global_params, systems, unique_id)
+    groups = check.physical_megaraid_disks(systems, unique_id)
     compare_sets.compute_similar_hosts_list(
         systems_groups,
         compare_sets.get_hosts_list_from_result(groups))
     systems = utils.find_sub_element(bench_values, unique_id, 'disk')
-    groups = check.physical_hpa_disks(global_params, systems, unique_id)
+    groups = check.physical_hpa_disks(systems, unique_id)
     compare_sets.compute_similar_hosts_list(
         systems_groups,
         compare_sets.get_hosts_list_from_result(groups))
-    groups = check.logical_disks(global_params, systems, unique_id)
+    groups = check.logical_disks(systems, unique_id)
     compare_sets.compute_similar_hosts_list(
         systems_groups,
         compare_sets.get_hosts_list_from_result(groups))
@@ -109,7 +109,7 @@ def group_systems(global_params, bench_values, unique_id,
             ('firmware', check.firmware, "Firmware"),
             ('memory', check.memory_timing, "DDR Timing"),
             ('network', check.network_interfaces,
-                "Network Interfaces"),
+             "Network Interfaces"),
             ('cpu', check.cpu, "Processors")):
         if name not in ignore_list:
             compare_type(name, func, title, global_params, bench_values,

--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -249,7 +249,7 @@ def do_plot(current_dir, gpm_dir, main_title, subtitle, name, unit, titles,
         gnuplot_arg = lambda x: "ARG" + str(x + 1)
     else:
         gnuplot_arg = lambda x: "'$" + str(x) + "'"
-    with open(filename, "a") as f:
+    with open(filename, "a") as ofile:
         shutil.copyfile("%s/graph2D.gpm" % gpm_dir,
                         "%s/graph2D.gpm" % current_dir)
         with open("%s/graph2D.gpm" % current_dir, "a") as myfile:
@@ -308,20 +308,20 @@ def do_plot(current_dir, gpm_dir, main_title, subtitle, name, unit, titles,
                              (expected_value, expected_value))
             myfile.write("\n")
 
-        f.write("call \'%s/graph2D.gpm\' \"%s\" \"%s\" \'%s\' \'%s\' \'%s\' "
-                "\'%s\'\n" % (current_dir, main_title, subtitle,
-                              current_dir + "/" + name + ".plot",
-                              name, current_dir + name, unit))
+        ofile.write("call \'%s/graph2D.gpm\' \"%s\" \"%s\" \'%s\' \'%s\' "
+                    "\'%s\' \'%s\'\n" % (current_dir, main_title, subtitle,
+                                         current_dir + "/" + name + ".plot",
+                                         name, current_dir + name, unit))
     try:
         os.system("gnuplot %s" % filename)
     except Exception:
         pass
 
 
-def extract_hw_info(hw, level1, level2, level3):
+def extract_hw_info(hardware, level1, level2, level3):
     result = []
     temp_level2 = level2
-    for entry in hw:
+    for entry in hardware:
         if level2 == '*':
             temp_level2 = entry[1]
         if (level1 == entry[0] and temp_level2 == entry[1] and

--- a/hardware/cardiff/cardiff.py
+++ b/hardware/cardiff/cardiff.py
@@ -88,28 +88,31 @@ def compare_disks(global_params, bench_values, unique_id, systems_groups):
         compare_sets.get_hosts_list_from_result(groups))
 
 
-def compare_type(type_, check_func, global_params,
+def compare_type(type_, check_func, title, global_params,
                  bench_values, unique_id, systems_groups):
     systems = utils.find_sub_element(bench_values, unique_id, type_)
-    groups = check_func(global_params, systems, unique_id)
+    groups = check_func(systems, unique_id)
     compare_sets.compute_similar_hosts_list(
         systems_groups,
         compare_sets.get_hosts_list_from_result(groups))
+    compare_sets.print_groups(global_params, groups, title)
 
 
 def group_systems(global_params, bench_values, unique_id,
                   systems_groups, ignore_list):
-    for name, func in (('hpa', check.hpa),
-                       ('megaraid', check.megaraid),
-                       ('ahci', check.ahci),
-                       ('ipmi', check.ipmi),
-                       ('system', check.systems),
-                       ('firmware', check.firmware),
-                       ('memory', check.memory_timing),
-                       ('network', check.network_interfaces),
-                       ('cpu', check.cpu)):
+    for name, func, title in (
+            ('hpa', check.hpa, "HPA Controller"),
+            ('megaraid', check.megaraid, "Megaraid Controller"),
+            ('ahci', check.ahci, "AHCI Controller"),
+            ('ipmi', check.ipmi, "IPMI SDR"),
+            ('system', check.systems, "System"),
+            ('firmware', check.firmware, "Firmware"),
+            ('memory', check.memory_timing, "DDR Timing"),
+            ('network', check.network_interfaces,
+                "Network Interfaces"),
+            ('cpu', check.cpu, "Processors")):
         if name not in ignore_list:
-            compare_type(name, func, global_params, bench_values,
+            compare_type(name, func, title, global_params, bench_values,
                          unique_id, systems_groups)
 
 

--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -27,10 +27,10 @@ from hardware.cardiff import perf_cpu_tables
 from hardware.cardiff import utils
 
 
-def search_item(systems, unique_id, item, regexp, exclude_list=[],
+def search_item(system_list, unique_id, item, regexp, exclude_list=[],
                 include_list=[], override_list=[]):
     sets = {}
-    for system in systems:
+    for system in system_list:
         sets[system[unique_id]] = set()
         current_set = sets[system[unique_id]]
         for stuff in system[item]:
@@ -64,35 +64,35 @@ def search_item(systems, unique_id, item, regexp, exclude_list=[],
     return sets
 
 
-def physical_hpa_disks(systems, unique_id):
-    sets = search_item(systems, unique_id, "disk", r"(\d+)I:(\d+):(\d+)",
+def physical_hpa_disks(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "disk", r"(\d+)I:(\d+):(\d+)",
                        ['current_temperature_(c)',
                         'maximum_temperature_(c)',
                         'serial_number'])
     return compare_sets.compare(sets)
 
 
-def physical_megaraid_disks(systems, unique_id):
-    sets = search_item(systems, unique_id, "pdisk", r"disk(\d+)",
+def physical_megaraid_disks(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "pdisk", r"disk(\d+)",
                        ['Wwn', 'SasAddress', 'DriveTemperature'])
     return compare_sets.compare(sets)
 
 
-def logical_disks(systems, unique_id):
-    sets = search_item(systems, unique_id, "disk", r"[a-z]d(\S+)",
+def logical_disks(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "disk", r"[a-z]d(\S+)",
                        ['simultaneous', 'standalone', 'id', 'serial_number',
                         'SMART/'], [],
                        ['when_failed', 'vendor', 'product', 'health'])
     return compare_sets.compare(sets)
 
 
-def ahci(systems, unique_id):
-    sets = search_item(systems, unique_id, "ahci", r".*")
+def ahci(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "ahci", r".*")
     return compare_sets.compare(sets)
 
 
-def ipmi(systems, unique_id):
-    sets = search_item(systems, unique_id, "ipmi",
+def ipmi(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "ipmi",
                        "(?!(.*Temp$|.*RPM$)).*",
                        ['mac-address', 'ip-address'])
     return compare_sets.compare(sets)
@@ -152,10 +152,10 @@ def prepare_detail(detail_options, group_number, category, item, details,
     return ""
 
 
-def network_perf(systems, unique_id, group_number, detail_options,
+def network_perf(system_list, unique_id, group_number, detail_options,
                  rampup_value=0, current_dir=""):
     have_net_data = False
-    sets = search_item(systems, unique_id, "network", r"(.*)", [], [])
+    sets = search_item(system_list, unique_id, "network", r"(.*)", [], [])
     modes = ['bandwidth', 'requests_per_sec']
     for mode in sorted(modes):
         results = {}
@@ -206,10 +206,10 @@ def network_perf(systems, unique_id, group_number, detail_options,
         print_detail(detail_options, details, df, matched_category)
 
 
-def logical_disks_perf(systems, unique_id, group_number, detail_options,
+def logical_disks_perf(system_list, unique_id, group_number, detail_options,
                        perf_unit, rampup_value=0, current_dir=""):
     have_disk_data = False
-    sets = search_item(systems, unique_id, "disk", r"[a-z]d(\S+)", [],
+    sets = search_item(system_list, unique_id, "disk", r"[a-z]d(\S+)", [],
                        ['simultaneous', 'standalone'])
     modes = []
 
@@ -270,48 +270,48 @@ def logical_disks_perf(systems, unique_id, group_number, detail_options,
         print_detail(detail_options, details, df, matched_category)
 
 
-def hpa(systems, unique_id):
-    sets = search_item(systems, unique_id, "hpa", "(.*)",
+def hpa(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "hpa", "(.*)",
                        ['cache_serial_number', 'serial_number'])
     return compare_sets.compare(sets)
 
 
-def megaraid(systems, unique_id):
-    sets = search_item(systems, unique_id, "megaraid", "(.*)",
+def megaraid(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "megaraid", "(.*)",
                        ['SerialNo', 'SasAddress', 'ControllerTemperature',
                         'VendorSpecific', 'RocTemperature'])
     return compare_sets.compare(sets)
 
 
-def systems(systems, unique_id):
-    sets = search_item(systems, unique_id, "system", "(.*)",
+def systems(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "system", "(.*)",
                        ['serial', 'uuid'])
     return compare_sets.compare(sets)
 
 
-def firmware(systems, unique_id):
-    sets = search_item(systems, unique_id, "firmware", "(.*)")
+def firmware(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "firmware", "(.*)")
     return compare_sets.compare(sets)
 
 
-def memory_timing(systems, unique_id):
-    sets = search_item(systems, unique_id, "memory", "DDR(.*)")
+def memory_timing(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "memory", "DDR(.*)")
     return compare_sets.compare(sets)
 
 
-def memory_banks(systems, unique_id):
-    sets = search_item(systems, unique_id, "memory", "bank(.*)", ['serial'])
+def memory_banks(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "memory", "bank(.*)", ['serial'])
     return compare_sets.compare(sets)
 
 
-def network_interfaces(systems, unique_id):
-    sets = search_item(systems, unique_id, "network", "(.*)",
+def network_interfaces(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "network", "(.*)",
                        ['serial', 'ipv4'])
     return compare_sets.compare(sets)
 
 
-def cpu(systems, unique_id):
-    sets = search_item(systems, unique_id, "cpu", "(.*)",
+def cpu(system_list, unique_id):
+    sets = search_item(system_list, unique_id, "cpu", "(.*)",
                        ['bogomips', 'loops_per_sec', 'bandwidth',
                         'cache_size', '/temperature'])
     return compare_sets.compare(sets)
@@ -454,12 +454,12 @@ def print_summary(mode, array, array_name, unit, df, item_value=None):
             mean, unit, numpy.std(result), perf_status)
 
 
-def cpu_perf(systems, unique_id, group_number, detail_options,
+def cpu_perf(system_list, unique_id, group_number, detail_options,
              rampup_value=0, current_dir=""):
     have_cpu_data = False
-    host_cpu_list = search_item(systems, unique_id, "cpu", "(.*)", [],
+    host_cpu_list = search_item(system_list, unique_id, "cpu", "(.*)", [],
                                 ['product'])
-    host_cpu_number = search_item(systems, unique_id, "cpu",
+    host_cpu_number = search_item(system_list, unique_id, "cpu",
                                   "(.*logical.*)", [], ['number'])
     core_counts = 1
     for host in host_cpu_number:
@@ -474,7 +474,7 @@ def cpu_perf(systems, unique_id, group_number, detail_options,
             break
 
     modes = ['bogomips', 'loops_per_sec']
-    sets = search_item(systems, unique_id, "cpu", "(.*)", [], modes)
+    sets = search_item(system_list, unique_id, "cpu", "(.*)", [], modes)
     global_perf = dict()
     for mode in sorted(modes):
         results = {}
@@ -563,11 +563,11 @@ def cpu_perf(systems, unique_id, group_number, detail_options,
             print_summary("CPU Efficiency", unstable, "unstable", '%', cpu_eff)
 
 
-def memory_perf(systems, unique_id, group_number, detail_options,
+def memory_perf(system_list, unique_id, group_number, detail_options,
                 rampup_value=0, current_dir=""):
     have_memory_data = False
     modes = ['1K', '4K', '1M', '16M', '128M', '256M', '1G', '2G']
-    sets = search_item(systems, unique_id, "cpu", "(.*)", [], modes)
+    sets = search_item(system_list, unique_id, "cpu", "(.*)", [], modes)
     for mode in sorted(modes):
         real_mode = "Memory benchmark %s" % mode
         results = {}

--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -127,10 +127,10 @@ def prepare_detail(detail_options, group_number, category, item, details,
     matched_item = ''
 
     if detail_options['group'] == str(group_number):
-            matched_group = str(group_number)
+        matched_group = str(group_number)
     elif re.search(detail_options['group'], str(group_number)) is not None:
-            matched_group = re.search(detail_options['group'],
-                                      str(group_number)).group()
+        matched_group = re.search(detail_options['group'],
+                                  str(group_number)).group()
 
     if detail_options['category'] in category:
         matched_category = category
@@ -300,7 +300,8 @@ def memory_timing(system_list, unique_id):
 
 
 def memory_banks(system_list, unique_id):
-    sets = search_item(system_list, unique_id, "memory", "bank(.*)", ['serial'])
+    sets = search_item(system_list, unique_id, "memory", "bank(.*)",
+                       ['serial'])
     return compare_sets.compare(sets)
 
 

--- a/hardware/cardiff/check.py
+++ b/hardware/cardiff/check.py
@@ -64,50 +64,38 @@ def search_item(systems, unique_id, item, regexp, exclude_list=[],
     return sets
 
 
-def physical_hpa_disks(global_params, systems, unique_id):
+def physical_hpa_disks(systems, unique_id):
     sets = search_item(systems, unique_id, "disk", r"(\d+)I:(\d+):(\d+)",
                        ['current_temperature_(c)',
                         'maximum_temperature_(c)',
                         'serial_number'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups,
-                              "Physical Disks (HP Controllers)")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def physical_megaraid_disks(global_params, systems, unique_id):
+def physical_megaraid_disks(systems, unique_id):
     sets = search_item(systems, unique_id, "pdisk", r"disk(\d+)",
                        ['Wwn', 'SasAddress', 'DriveTemperature'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups,
-                              "Physical Disks (Megaraid Controllers)")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def logical_disks(global_params, systems, unique_id):
+def logical_disks(systems, unique_id):
     sets = search_item(systems, unique_id, "disk", r"[a-z]d(\S+)",
                        ['simultaneous', 'standalone', 'id', 'serial_number',
                         'SMART/'], [],
                        ['when_failed', 'vendor', 'product', 'health'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Logical Disks")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def ahci(global_params, systems, unique_id):
+def ahci(systems, unique_id):
     sets = search_item(systems, unique_id, "ahci", r".*")
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "AHCI Controller")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def ipmi(global_params, systems, unique_id):
+def ipmi(systems, unique_id):
     sets = search_item(systems, unique_id, "ipmi",
                        "(?!(.*Temp$|.*RPM$)).*",
                        ['mac-address', 'ip-address'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "IPMI SDR")
-    return groups
+    return compare_sets.compare(sets)
 
 
 def compute_deviance_percentage(item, df):
@@ -282,67 +270,51 @@ def logical_disks_perf(systems, unique_id, group_number, detail_options,
         print_detail(detail_options, details, df, matched_category)
 
 
-def hpa(global_params, systems, unique_id):
+def hpa(systems, unique_id):
     sets = search_item(systems, unique_id, "hpa", "(.*)",
                        ['cache_serial_number', 'serial_number'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "HPA Controller")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def megaraid(global_params, systems, unique_id):
+def megaraid(systems, unique_id):
     sets = search_item(systems, unique_id, "megaraid", "(.*)",
                        ['SerialNo', 'SasAddress', 'ControllerTemperature',
                         'VendorSpecific', 'RocTemperature'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Megaraid Controller")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def systems(global_params, systems, unique_id):
+def systems(systems, unique_id):
     sets = search_item(systems, unique_id, "system", "(.*)",
                        ['serial', 'uuid'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "System")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def firmware(global_params, systems, unique_id):
+def firmware(systems, unique_id):
     sets = search_item(systems, unique_id, "firmware", "(.*)")
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Firmware")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def memory_timing(global_params, systems, unique_id):
+def memory_timing(systems, unique_id):
     sets = search_item(systems, unique_id, "memory", "DDR(.*)")
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Memory Timing(RAM)")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def memory_banks(global_params, systems, unique_id):
+def memory_banks(systems, unique_id):
     sets = search_item(systems, unique_id, "memory", "bank(.*)", ['serial'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Memory Banks(RAM)")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def network_interfaces(global_params, systems, unique_id):
+def network_interfaces(systems, unique_id):
     sets = search_item(systems, unique_id, "network", "(.*)",
                        ['serial', 'ipv4'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Network Interfaces")
-    return groups
+    return compare_sets.compare(sets)
 
 
-def cpu(global_params, systems, unique_id):
+def cpu(systems, unique_id):
     sets = search_item(systems, unique_id, "cpu", "(.*)",
                        ['bogomips', 'loops_per_sec', 'bandwidth',
                         'cache_size', '/temperature'])
-    groups = compare_sets.compare(sets)
-    compare_sets.print_groups(global_params, groups, "Processors")
-    return groups
+    return compare_sets.compare(sets)
 
 
 def print_perf(tolerance_min, tolerance_max, item, df, mode, title,

--- a/hardware/cardiff/utils.py
+++ b/hardware/cardiff/utils.py
@@ -69,11 +69,11 @@ def do_print(mode, level, string, *args):
 def find_file(path, pattern):
     health_data_file = []
     # For all the local files
-    for file in os.listdir(path):
+    for my_file in os.listdir(path):
         # If the file math the regexp
-        if fnmatch.fnmatch(file, pattern):
+        if fnmatch.fnmatch(my_file, pattern):
             # Let's consider this file
-            health_data_file.append(path + "/" + file)
+            health_data_file.append(path + "/" + my_file)
 
     return health_data_file
 

--- a/hardware/tests/test_cardiff_check.py
+++ b/hardware/tests/test_cardiff_check.py
@@ -19,7 +19,6 @@ import os
 import unittest
 
 from hardware.cardiff import check
-from hardware.cardiff import compare_sets
 from hardware.cardiff import utils
 
 

--- a/hardware/tests/test_cardiff_check.py
+++ b/hardware/tests/test_cardiff_check.py
@@ -36,10 +36,9 @@ class TestDetect(unittest.TestCase):
     def test_cpu(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(check.search_item(
-            utils.find_sub_element(l, 'serial', 'cpu'), 'serial',
-            "cpu", "(.*)", ['bogomips', 'loops_per_sec', 'bandwidth',
-                            'cache_size']))
+        result = check.cpu(utils.find_sub_element(l, 'serial', 'cpu'),
+                           'serial')
+
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -74,10 +73,8 @@ class TestDetect(unittest.TestCase):
     def test_network_interfaces(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(
-            check.search_item(
-                utils.find_sub_element(l, 'serial', 'network'),
-                'serial', "network", "(.*)", ['serial', 'ipv4']))
+        result = check.network_interfaces(
+            utils.find_sub_element(l, 'serial', 'network'), 'serial')
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -104,9 +101,9 @@ class TestDetect(unittest.TestCase):
     def test_memory_timing(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(
-            check.search_item(utils.find_sub_element(l, 'serial', 'memory'),
-                              'serial', "memory", "DDR(.*)"))
+        result = check.memory_timing(utils.find_sub_element(l, 'serial',
+                                                            'memory'),
+                                     'serial')
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -155,9 +152,8 @@ class TestDetect(unittest.TestCase):
     def test_firmware(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(
-            check.search_item(utils.find_sub_element(l, 'serial', 'firmware'),
-                              'serial', "firmware", "(.*)"))
+        result = check.firmware(
+            utils.find_sub_element(l, 'serial', 'firmware'), 'serial')
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -175,9 +171,8 @@ class TestDetect(unittest.TestCase):
     def test_systems(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(check.search_item(
-            utils.find_sub_element(l, 'serial', 'system'),
-            'serial', "system", "(.*)", ['serial']))
+        result = check.systems(
+            utils.find_sub_element(l, 'serial', 'system'), 'serial')
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -196,10 +191,8 @@ class TestDetect(unittest.TestCase):
     def test_logical_disks(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(
-            check.search_item(utils.find_sub_element(l, 'serial', 'disk'),
-                              'serial', "disk", "sd(\S+)",
-                              ['simultaneous', 'standalone']))
+        result = check.logical_disks(
+            utils.find_sub_element(l, 'serial', 'disk'), 'serial')
         self.maxDiff = None
         for element in result:
             group = result[element]
@@ -226,9 +219,9 @@ class TestDetect(unittest.TestCase):
     def test_hp_physical_disks(self):
         l = []
         load_samples(l)
-        result = compare_sets.compare(check.search_item(
-            utils.find_sub_element(l, 'serial', 'disk'),
-            'serial', "disk", "(\d+)I:(\d+):(\d+)"))
+        result = check.physical_hpa_disks(utils.find_sub_element(l, 'serial',
+                                                                 'disk'),
+                                          'serial')
         self.maxDiff = None
         item = 0
         for element in result:

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands = {posargs}
 commands = {toxinidir}/tools/check-coverage.sh 45 {toxinidir} {posargs}
 
 [testenv:pylint]
-commands = bash -c "{toxinidir}/tools/check-pylint-score.sh 8.89 -j $(nproc) --rcfile {toxinidir}/tools/pylintrc $(find {toxinidir}/hardware -name '*.py'|grep -v '^{toxinidir}/hardware/tests')"
+commands = bash -c "{toxinidir}/tools/check-pylint-score.sh 8.91 -j $(nproc) --rcfile {toxinidir}/tools/pylintrc $(find {toxinidir}/hardware -name '*.py'|grep -v '^{toxinidir}/hardware/tests')"
 
 [testenv:docs]
 commands = python setup.py build_sphinx


### PR DESCRIPTION
This PR is linked to PR #31.

The testing code was not using functions from check and so duplicated most of the filtering code.
This PR is split in two commits ::
- One to make the check.*() functions having a clean behavior for being called by the testing code
- one to change the code in the test code to reuse the check.*() code

Once this PR will be merged, PR#31 can be merged too.

Thanks,