### PR TITLE
detect: Moving disk's information order

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -233,8 +233,7 @@ def detect_disks(hw_lst):
     disks = [name for name, size in sizes.items() if size > 0]
     hw_lst.append(('disk', 'logical', 'count', str(len(disks))))
     for name in disks:
-        hw_lst.append(('disk', name, 'size', str(sizes[name])))
-        item_list = ['device/vendor', 'device/model', 'device/rev',
+        item_list = ['device/model', 'device/vendor', 'device/rev',
                      'queue/optimal_io_size', 'queue/physical_block_size',
                      'queue/rotational']
         for my_item in item_list:
@@ -248,6 +247,8 @@ def detect_disks(hw_lst):
                     'at /sys/block/%s/device/%s: %s\n' % (name,
                                                           my_item,
                                                           str(excpt)))
+
+        hw_lst.append(('disk', name, 'size', str(sizes[name])))
 
         item_list = ['WCE', 'RCD']
         item_def = {'WCE': 'Write Cache Enable', 'RCD': 'Read Cache Disable'}


### PR DESCRIPTION
This patch is about inverting some disk info to ease making proper edeploy's
role with it.

The actual code was printing disk's info in the following order :

    size
    vendor
    model
    <other>

When reusing an hardware output as a edpeloy role, that's an issue and edeploy
requires the top discriminating element first. This patch just invert the order
like :

    model
    vendor
    <other>
    size

This way turning an hw report to an edeploy role is much easier.