### PR TITLE
matcher: Adding range() function

### DIFF
--- a/hardware/matcher.py
+++ b/hardware/matcher.py
@@ -42,6 +42,11 @@ def _appender(array, index, value):
         array[index] = [value, ]
 
 
+def _range(elt, minval, maxval):
+    'Helper for match_spec.'
+    return float(elt) >= float(minval) and float(elt) <= float(maxval)
+
+
 def _gt(left, right):
     'Helper for match_spec.'
     return float(left) > float(right)

--- a/hardware/tests/test_matcher.py
+++ b/hardware/tests/test_matcher.py
@@ -276,6 +276,19 @@ class TestMatcher(unittest.TestCase):
         self.assertTrue(matcher.match_all(lines, specs, arr, {}))
         self.assertEqual(arr['disk'], 'vda')
 
+    def test_rangeint(self):
+        specs = [('disk', '$disk', 'size', 'range(20, 25)')]
+        lines = [('disk', 'vda', 'size', '20')]
+        arr = {}
+        self.assertTrue(matcher.match_all(lines, specs, arr, {}))
+        self.assertEqual(arr['disk'], 'vda')
+
+    def test_rangefloat(self):
+        specs = [('ipmi', '+12V', 'value', 'range(11.9, 12.2)')]
+        lines = [('ipmi', '+12V', 'value', '12.14')]
+        arr = {}
+        self.assertTrue(matcher.match_all(lines, specs, arr, {}))
+
     def test_regexp(self):
         specs = [('network', '$eth', 'serial', 'regexp(^28:d2:)')]
         lines = [('network', 'eth0', 'serial', '28:d2:44:1b:0a:8b')]


### PR DESCRIPTION
This patch add a new spec helper called 'range'

It does allow putting a matching rule to check if a value is part of a range.

The prototype is like range(lower_bound, upper_bound) and the code return True
if (lower_bound <= x <= upper_bound).

A typical usage would be :

 ('ipmi', '+12 V', 'value', 'range(11.8, 12.2)'),