### PR TITLE
Fix Python 3 issues

### DIFF
--- a/hardware/areca.py
+++ b/hardware/areca.py
@@ -91,7 +91,11 @@ def split_parts(sep, output):
 def run_areca(*args):
     'Run the areca command in a subprocess and return the output.'
     cmd = 'cli64 ' + ' '.join(args)
-    return Popen(cmd, shell=True, stdout=PIPE).stdout.read(-1)
+    proc = Popen(cmd,
+                 shell=True,
+                 stdout=PIPE,
+                 universal_newlines=True)
+    return proc.communicate()[0]
 
 
 def run_and_parse(*args):

--- a/hardware/cardiff/compare_sets.py
+++ b/hardware/cardiff/compare_sets.py
@@ -112,7 +112,7 @@ def compute_similar_hosts_list(systems_groups, new_groups):
             intersection = set.intersection(systems_group, group)
             if (len(intersection) < len(systems_group) and
                     len(intersection) > 0):
-                # print "%d vs %d" % (len(intersection), len(systems_group))
+                # print("%d vs %d" % (len(intersection), len(systems_group)))
                 # We do have a partial match meaning we shall break
                 # the existing group in pieces
                 difference = set.difference(systems_group, group)

--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -301,7 +301,8 @@ def detect_disks(hw_lst):
             sdparm_cmd = Popen("sdparm -q --get=%s /dev/%s | "
                                "awk '{print $2}'" % (my_item, name),
                                shell=True,
-                               stdout=PIPE)
+                               stdout=PIPE,
+                               universal_newlines=True)
             for line in sdparm_cmd.stdout:
                 hw_lst.append(('disk', name, item_def.get(my_item),
                                line.rstrip('\n').strip()))
@@ -421,8 +422,10 @@ def get_uuid():
     uuid_cmd = Popen("dmidecode -t 1 | grep UUID | "
                      "awk '{print $2}'",
                      shell=True,
-                     stdout=PIPE)
-    return uuid_cmd.stdout.read().rstrip()
+                     stdout=PIPE,
+                     universal_newlines=True)
+    stdout = uuid_cmd.communicate()[0]
+    return stdout.rstrip()
 
 
 def _get_value(hw_lst, *vect):

--- a/hardware/detect_utils.py
+++ b/hardware/detect_utils.py
@@ -28,15 +28,16 @@ import sys
 def cmd(cmdline):
     'Equivalent of commands.getstatusoutput'
     try:
-        return 0, check_output(cmdline, shell=True)
+        return 0, check_output(cmdline, shell=True, universal_newlines=True)
     except CalledProcessError as excpt:
         return excpt.returncode, excpt.output
 
 
 def output_lines(cmdline):
     "Run a shell command and returns the output as lines."
-    res = Popen(cmdline, shell=True, stdout=PIPE)
-    return res.stdout
+    proc = Popen(cmdline, shell=True, stdout=PIPE, universal_newlines=True)
+    stdout = proc.communicate()[0]
+    return stdout.splitlines()
 
 
 def parse_lldtool(hw_lst, interface_name, lines):
@@ -191,12 +192,12 @@ def read_SMART_SCSI(hw, device, optional_flag="", mode=""):
             # we can bypass it
             if optional_flag == "":
                 if (vendor == "DELL") and ("PERC" in product):
-                    for pdisk_number in xrange(0, 24):
+                    for pdisk_number in range(0, 24):
                         read_SMART_SCSI(hw, device,
                                         "-d megaraid,%d" % pdisk_number,
                                         "megaraid")
                 if (vendor == "HP") and ("LOGICAL VOLUME" in product):
-                    for pdisk_number in xrange(0, 24):
+                    for pdisk_number in range(0, 24):
                         read_SMART_SCSI(hw, device,
                                         "-d cciss,%d" % pdisk_number, "cciss")
             return hw
@@ -437,5 +438,6 @@ def parse_ipmi_sdr(hrdw, output):
 def ipmi_sdr(hrdw):
     ipmi_cmd = Popen("ipmitool -I open sdr",
                      shell=True,
-                     stdout=PIPE)
+                     stdout=PIPE,
+                     universal_newlines=True)
     parse_ipmi_sdr(hrdw, ipmi_cmd.stdout)

--- a/hardware/diskinfo.py
+++ b/hardware/diskinfo.py
@@ -27,7 +27,7 @@ def sizeingb(size):
 
 def disksize(name):
     size = open('/sys/block/' + name + '/size').read(-1)
-    return sizeingb(long(size))
+    return sizeingb(int(size))
 
 
 def disknames():

--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -22,6 +22,9 @@ import re
 import sys
 import types
 
+from six.moves import range
+
+
 _PREFIX = None
 
 
@@ -100,10 +103,10 @@ Ranges are defined like 10-12:15-18 or from a list of entries.
                 for num in _generate_range(res.group(2)):
                     yield head + num + foot
             else:
-                for _ in xrange(16387064):
+                for _ in range(16387064):
                     yield pattern
     else:
-        for _ in xrange(16387064):
+        for _ in range(16387064):
             yield pattern
 
 

--- a/hardware/megacli.py
+++ b/hardware/megacli.py
@@ -125,7 +125,8 @@ def run_megacli(*args):
     prog_exec = search_exec(["megacli", "MegaCli", "MegaCli64"])
     if prog_exec:
         cmd = prog_exec + ' - ' + ' '.join(args)
-        return Popen(cmd, shell=True, stdout=PIPE).stdout.read(-1)
+        proc = Popen(cmd, shell=True, stdout=PIPE, universal_newlines=True)
+        return proc.communicate()[0]
     else:
         sys.stderr.write('Cannot find megacli on the system\n')
         return ""

--- a/hardware/tests/test_diskinfo.py
+++ b/hardware/tests/test_diskinfo.py
@@ -27,7 +27,7 @@ if sys.version > '3':
 class TestDiskinfo(unittest.TestCase):
 
     def test_sizeingb(self):
-        return self.assertEqual(diskinfo.sizeingb(977105060), long(500))
+        return self.assertEqual(diskinfo.sizeingb(977105060), 500)
 
     def test_parse_hdparm_output(self):
         return self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=0.8.2,<1.0
+six
 Babel>=1.3
 netaddr
 pexpect


### PR DESCRIPTION
* Replace long(500) with 500. long type was replaced with the int
  type in Python 3.
* Fix a commented print statement
* Replace xrange() with range() or six.moves.range() depending on the
  size of the range.
* Use universal_newlines to get stdout as text (Unicode) on Python 3
  instead of bytes. Use also communicate() which is more reliable and
  standard than stdout.read().
* Replace long(str) with int(str)