### PR TITLE
New task in hardware detection: detect RTC setting.

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -45,6 +45,7 @@ from hardware import hpacucli
 from hardware import infiniband as ib
 from hardware import ipmi
 from hardware import megacli
+from hardware import rtc
 
 SIOCGIFNETMASK = 0x891b
 
@@ -755,6 +756,10 @@ def detect_temperatures(hwlst):
                                processor_num, "critical_alarm")
 
 
+def detect_rtc_clock(hw_lst):
+    hw_lst.append(('system', 'rtc', 'utc', rtc.get_rtc()))
+
+
 def parse_ahci(hrdw, words):
     if len(words) < 4:
         return
@@ -805,6 +810,7 @@ def _main(options):
     detect_temperatures(hrdw)
     detect_utils.get_ddr_timing(hrdw)
     detect_utils.ipmi_sdr(hrdw)
+    detect_rtc_clock(hrdw)
     _, output = cmd("dmesg")
     parse_dmesg(hrdw, output)
 

--- a/hardware/rtc.py
+++ b/hardware/rtc.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2014-2015 Red Hat Inc.
+#
+# Author: Cedric Jeanneret <cjeanner@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+'''
+'''
+import logging
+import re
+from subprocess import check_output
+
+LOG = logging.getLogger('hardware.rtc')
+
+
+def get_rtc():
+    cmd = ['timedatectl', 'status', '--no-pager']
+    stdout = check_output(cmd).decode("utf-8")
+    if stdout:
+        match = re.search(r'RTC in local TZ: ([a-z]+)$', stdout)
+        if match:
+            LOG.info('Is RTC set to UTC: %s' % match.group(1))
+            return match.group(1)
+        else:
+            LOG.warning('Unable to determine RTC timezone (no match)')
+    else:
+            LOG.warning('Unable to determine RTC timezone (no output)')
+    return 'unknown'


### PR DESCRIPTION
This will allow to add a new validation before deploying so that
tripleo won't deploy anything until hardware clocks are set to RTC.

This setting is mandatory in order to prevent any issues regarding
timezone, future-dated files and so on.

More information: https://storyboard.openstack.org/#!/story/2002926

Story: 2002926