### PR TITLE
Adding how to install

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,12 +1,12 @@
 If you would like to contribute to the development of the hardware
 module, use Pull Requests from github:
 
-   https://github.com/enovance/hardware
+   https://github.com/redhat-cip/hardware
 
 To report a bug, take a look if you bug has already been reported on:
 
-https://github.com/enovance/hardware/issues
+https://github.com/redhat-cip/hardware/issues
 
 If your bug is new, it should be filed on GitHub:
 
-   https://github.com/enovance/hardware/issues/new
+   https://github.com/redhat-cip/hardware/issues/new

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,13 @@ Features
 
 * filter hardware according to hardware profiles
 
+Install
+-------
+
+Installing from pypi::
+
+    pip install -U hardware
+
 Usage
 -----
 


### PR DESCRIPTION
Hi!

# Overview
Adding how to install `hardware`

Replace oldest repository from enovance to redhat-cip