### PR TITLE
Add a system UUID on ppc64le

### DIFF
--- a/hardware/infiniband.py
+++ b/hardware/infiniband.py
@@ -27,7 +27,7 @@ def ib_card_drv():
     ret, output = cmd('ibstat -l')
     if ret == 0:
         # Use filter to omit empty item due to trailing newline.
-        return filter(None, output.split('\n'))
+        return list(filter(None, output.split('\n')))
     else:
         return []
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=0.9.34
 pylint==1.4.1
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,18 @@ commands = flake8
 commands = {posargs}
 
 [testenv:cover]
+whitelist_externals =
+    /bin/sh
+    /bin/bash
+    /usr/bin/bash
 commands = {toxinidir}/tools/check-coverage.sh 45 {toxinidir} {posargs}
 
 [testenv:pylint]
+basepython = python2
+whitelist_externals =
+    /bin/sh
+    /bin/bash
+    /usr/bin/bash
 commands = bash -c "{toxinidir}/tools/check-pylint-score.sh 8.91 -j $(nproc) --rcfile {toxinidir}/tools/pylintrc $(find {toxinidir}/hardware -name '*.py'|grep -v '^{toxinidir}/hardware/tests')"
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py34,pep8,pylint,cover
+envlist = py34,py27,pep8,pylint,cover
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Currently hardware runs dmidecode to grab the system-uuid but on systems
that don't have DMI none is returned.  We can generate one from the
vendor and serial if that's found.  Or with a modern[1] OPAL firmware we
can just return the one from the device-tree

[1] Ok unreleased but with an open [RFE](https://github.com/open-power/skiboot/issues/193) ;P