### PR TITLE
Drop support for python 3.4 in favor of 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
 sudo: false
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
+  - '3.6'
 env:
   - TOX_ENV=unit
   - TOX_ENV=pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py34,py35,py27,pep8,pylint,cover
+envlist = py35,py36,py27,pep8,pylint,cover
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.4 final release will be 3.4.10 in March 2019.
We should drop support for it in favor of python 3.6.