### PR TITLE
hardware/hpacucli.py: Avoid PDs not being detected

### DIFF
--- a/hardware/hpacucli.py
+++ b/hardware/hpacucli.py
@@ -99,7 +99,7 @@ The regexp arg must extract the 4 informations from description lines.
     idx = None
     for line in output.split('\n'):
         line = line.strip()
-        if line[:5] == 'array' or line == 'unassigned':
+        if line[:5].lower() == 'array' or line.lower() == 'unassigned':
             if idx:
                 arr.append((idx, cur))
                 cur = []


### PR DESCRIPTION
While parsing the physical drives, the output of some versions of ssacli can report strings in various cases (upper/lower).
This patch makes the output in lower case to improve the matching.

Signed-off-by: Erwan Velu <e.velu@criteo.com>