### PR TITLE
Fixing pep8 error on newly landed hpacucli patch

### DIFF
--- a/hardware/hpacucli.py
+++ b/hardware/hpacucli.py
@@ -199,7 +199,9 @@ Must be called before any other method.
         # it.
         os.system('modprobe sg')
         path = None
-        for path2 in ('/usr/sbin/ssacli', '/usr/sbin/hpssacli', '/usr/sbin/hpacucli'):
+        for path2 in ('/usr/sbin/ssacli',
+                      '/usr/sbin/hpssacli',
+                      '/usr/sbin/hpacucli'):
             if os.path.exists(path2):
                 path = path2
                 break


### PR DESCRIPTION
After merging PR #54 pep8 testing is failing.
This patch fixes the issue.