### PR TITLE
Increasing pbr version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs
 parts
 bin
 var

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr>=0.8.2,<1.0
+pbr>=1.0
 six
 Babel>=1.3
 ipaddress


### PR DESCRIPTION
The version of pbr currently supported is a bit old.
Increasing version supported to 1.0 or higher.
Also adding .eggs to gitignore.