### PR TITLE
Rewriting tox.ini

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,7 +1,0 @@
-[DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
-             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
-             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,8 +10,6 @@ python-subunit
 sphinx>=1.1.2
 oslosphinx
 stestr>=2.0.0 # Apache-2.0
-testrepository>=0.0.18
-testscenarios>=0.4
 testtools>=0.9.34
 pylint>=1.4.2
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,29 @@ envlist = py35,py36,py37,py27,pep8,pylint,cover
 skipsdist = True
 
 [testenv]
+setenv = 
+    VIRTUAL_ENV={envdir}
+    PYTHONDONTWRITEBYTECODE=1
+    LANGUAGE=en_US
+    TESTS_DIR=./hardware/tests
 usedevelop = True
-install_command = pip install -U {opts} {packages}
-setenv =
-   VIRTUAL_ENV={envdir}
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+install_command =
+    pip install -U {opts} {packages}
+deps = 
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+commands =
+    stestr run {posargs}
 
 [testenv:pep8]
+basepython = python3
 commands = flake8
 
 [testenv:venv]
+basepython = python3
+deps = 
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands = {posargs}
 
 [testenv:cover]
@@ -32,7 +43,7 @@ commands =
     coverage xml -o cover/coverage.xml --omit='*tests*'
 
 [testenv:pylint]
-basepython = python2
+basepython = python3
 whitelist_externals =
     /bin/sh
     /bin/bash


### PR DESCRIPTION
Rewriting tox commands and options to improve testing and
remove the need of testrepository and testscenarios.

Bumping min tox version to 2.0 changes the default behavior
in case of errors from commands from 'ignore' to 'abort'
and allows the use of passenv option.

Also setting python3 as default python base.