### PR TITLE
hardware/megacli.py: Fixing typo

### DIFF
--- a/hardware/megacli.py
+++ b/hardware/megacli.py
@@ -43,7 +43,7 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
     # Additionally check that `file` is not a directory, as on Windows
     # directories pass the os.access check.
     def _access_check(myfile, mode):
-        return os.path.exists(myfile and os.access(myfile, mode) and not os.path.isdir(myfile))
+        return os.path.exists(myfile) and os.access(myfile, mode) and not os.path.isdir(myfile)
 
     # If we're given a path with a directory part, look it up directly rather
     # than referring to PATH directories. This includes checking relative to


### PR DESCRIPTION
Commit 54a78530fca3bfe81cfa54fc96e19ee7688280ca introduced a typo which broken the code as in :
	Traceback (most recent call last):
	  File "/usr/bin/hardware-detect", line 10, in <module>
	    sys.exit(main())
	  File "/usr/lib/python2.7/site-packages/hardware/detect.py", line 996, in main
	    _main(options)
	  File "/usr/lib/python2.7/site-packages/hardware/detect.py", line 921, in _main
	    detect_megacli(hrdw)
	  File "/usr/lib/python2.7/site-packages/hardware/detect.py", line 170, in detect_megacli
	    ctrl_num = megacli.adp_count()
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 148, in adp_count
	    arr = run_and_parse('adpCount')
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 142, in run_and_parse
	    res = run_megacli(*args)
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 127, in run_megacli
	    prog_exec = search_exec(["megacli", "MegaCli", "MegaCli64"])
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 84, in search_exec
	    prog_path = which(prog_name)
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 76, in which
	    if _access_check(name, mode):
	  File "/usr/lib/python2.7/site-packages/hardware/megacli.py", line 46, in _access_check
	    return os.path.exists(myfile and os.access(myfile, mode) and not os.path.isdir(myfile))
	  File "/usr/lib64/python2.7/genericpath.py", line 18, in exists
	    os.stat(path)
	TypeError: coercing to Unicode: need string or buffer, bool found

The misplaced parenthesis is the cause of that.

Thanks Yatin Karel for reporting.

Signed-off-by: Erwan Velu <e.velu@criteo.com>