### PR TITLE
Make the cache info collection more robust

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -736,8 +736,9 @@ def get_cpus(hw_lst):
         hw_lst.append(('cpu', "physical_{}".format(
             processor), 'stepping', int(lscpu['Stepping'])))
         for item in ['L1d cache', 'L1i cache', 'L2 cache', 'L3 cache']:
-            hw_lst.append(('cpu', "physical_{}".format(
-                processor), item.lower(), lscpu[item]))
+            if item in lscpu:
+                hw_lst.append(('cpu', "physical_{}".format(
+                    processor), item.lower(), lscpu[item]))
         if 'CPU min MHz' in lscpu:
             hw_lst.append(('cpu', "physical_{}".format(
                 processor), 'min_Mhz', float(lscpu['CPU min MHz'])))


### PR DESCRIPTION
On a RHEL8 VM L3 Cache does not exist and so we fail with:
Traceback (most recent call last):
  File "/bin/hardware-detect", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python3.6/site-packages/hardware/detect.py", line 996, in main
    _main(options)
  File "/usr/lib/python3.6/site-packages/hardware/detect.py", line 923, in _main
    if not detect_system(hrdw):
  File "/usr/lib/python3.6/site-packages/hardware/detect.py", line 666, in detect_system
    get_cpus(hw_lst)
  File "/usr/lib/python3.6/site-packages/hardware/detect.py", line 740, in get_cpus
    processor), item.lower(), lscpu[item]))
KeyError: 'L3 cache'

Only add the caches if they exist in the lscpu dict

Co-Authored-By: Damien Ciabrini <dciabrin@redhat.com>
Signed-off-by: Michele Baldessari <michele@acksyn.org>