### PR TITLE
Handle Architecture CPU information.

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -701,6 +701,16 @@ def _from_file(fname, mapping=None, default=None):
 
 
 def get_cpus(hw_lst):
+    def _maybe_int(v):
+        try:
+            base = 10
+            if 'x' in v:
+                base = 16
+            v = int(v, base)
+        except Exception:
+            pass
+        return v
+
     # Extracting lspcu information
     lscpu = {}
     output = detect_utils.output_lines('LANG=en_US.UTF-8 lscpu')
@@ -733,8 +743,8 @@ def get_cpus(hw_lst):
                                      ('cores', 'Core(s) per socket', int),
                                      ('threads', None, None),
                                      ('family', 'CPU family', int),
-                                     ('model', 'Model', int),
-                                     ('stepping', 'Stepping', int),
+                                     ('model', 'Model', _maybe_int),
+                                     ('stepping', 'Stepping', _maybe_int),
                                      ('l1d cache', 'L1d cache', None),
                                      ('l1i cache', 'L1i cache', None),
                                      ('l2 cache', 'L2 cache', None),

--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -721,49 +721,45 @@ def get_cpus(hw_lst):
 
     hw_lst.append(("cpu", "physical", "number", int(lscpu["Socket(s)"])))
     for processor in range(int(lscpu["Socket(s)"])):
+        ptag = "physical_{}".format(processor)
         (exists, value) = _from_file("/sys/devices/system/cpu/cpufreq/boost",
                                      mapping={'1': 'enabled'},
                                      default='disabled')
         if exists:
             hw_lst.append(
-                ('cpu', "physical_{}".format(processor), 'boost', value))
+                ('cpu', ptag, 'boost', value))
 
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'vendor', lscpu['Vendor ID']))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'product', lscpu['Model name']))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'cores', int(lscpu['Core(s) per socket'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'threads', int(lscpu['Thread(s) per core']) * int(lscpu['Core(s) per socket'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'family', int(lscpu['CPU family'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'model', int(lscpu['Model'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'stepping', int(lscpu['Stepping'])))
+        hw_lst.append(('cpu', ptag, 'vendor', lscpu['Vendor ID']))
+        hw_lst.append(('cpu', ptag, 'product', lscpu['Model name']))
+        hw_lst.append(('cpu', ptag, 'cores',
+                       int(lscpu['Core(s) per socket'])))
+        hw_lst.append(('cpu', ptag, 'threads',
+                       (int(lscpu['Thread(s) per core']) *
+                        int(lscpu['Core(s) per socket']))))
+        hw_lst.append(('cpu', ptag, 'family', int(lscpu['CPU family'])))
+        hw_lst.append(('cpu', ptag, 'model', int(lscpu['Model'])))
+        hw_lst.append(('cpu', ptag, 'stepping', int(lscpu['Stepping'])))
         for item in ['L1d cache', 'L1i cache', 'L2 cache', 'L3 cache']:
             if item in lscpu:
-                hw_lst.append(('cpu', "physical_{}".format(
-                    processor), item.lower(), lscpu[item]))
+                hw_lst.append(('cpu', ptag, item.lower(), lscpu[item]))
         if 'CPU min MHz' in lscpu:
-            hw_lst.append(('cpu', "physical_{}".format(
-                processor), 'min_Mhz', float(lscpu['CPU min MHz'])))
+            hw_lst.append(('cpu', ptag, 'min_Mhz',
+                           float(lscpu['CPU min MHz'])))
         if 'CPU max MHz' in lscpu:
-            hw_lst.append(('cpu', "physical_{}".format(
-                processor), 'max_Mhz', float(lscpu['CPU max MHz'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'current_Mhz', float(lscpu['CPU MHz'])))
-        hw_lst.append(('cpu', "physical_{}".format(
-            processor), 'flags', lscpu['Flags']))
+            hw_lst.append(('cpu', ptag, 'max_Mhz',
+                           float(lscpu['CPU max MHz'])))
+        hw_lst.append(('cpu', ptag, 'current_Mhz',
+                       float(lscpu['CPU MHz'])))
+        hw_lst.append(('cpu', ptag, 'flags', lscpu['Flags']))
 
     hw_lst.append(('cpu', 'logical', 'number', int(lscpu['CPU(s)'])))
     # Governors could be different on logical cpus
     for cpu in range(int(lscpu['CPU(s)'])):
+        ltag = "logical_{}".format(cpu)
         (exists, value) = _from_file(("/sys/devices/system/cpu/cpufreq/"
                                       "policy{}/scaling_governor".format(cpu)))
         if exists:
-            hw_lst.append(('cpu', "logical_{}".format(cpu), "governor", value))
+            hw_lst.append(('cpu', ltag, "governor", value))
 
     # Extracting numa nodes
     hw_lst.append(('numa', 'nodes', 'count', int(lscpu['NUMA node(s)'])))
@@ -779,6 +775,7 @@ def get_cpus(hw_lst):
     # on that.
     numa_nodes.sort(key=lambda t: t[1])
     for (key, node_id) in numa_nodes:
+        ntag = 'node_{}'.format(node_id)
         cpus = lscpu[key]
         # lscpu -x provides the cpu mask
         cpu_mask = lscpux[key]
@@ -803,10 +800,8 @@ def get_cpus(hw_lst):
                         total_cpus = total_cpus + max_cpu - min_cpu + 1
 
         # total_cpus = 12 for "0-5,48-53"
-        hw_lst.append(('numa', 'node_{}'.format(
-            node_id), 'cpu_count', total_cpus))
-        hw_lst.append(('numa', 'node_{}'.format(
-            node_id), 'cpu_mask', cpu_mask))
+        hw_lst.append(('numa', ntag, 'cpu_count', total_cpus))
+        hw_lst.append(('numa', ntag, 'cpu_mask', cpu_mask))
 
 
 def fix_bad_serial(hw_lst, uuid, mobo_id, nic_id):

--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -751,7 +751,7 @@ def get_cpus(hw_lst):
             processor), 'flags', lscpu['Flags']))
 
     hw_lst.append(('cpu', 'logical', 'number', int(lscpu['CPU(s)'])))
-    # Govenors could be differents on logical cpus
+    # Governors could be different on logical cpus
     for cpu in range(int(lscpu['CPU(s)'])):
         scaling_governor = "/sys/devices/system/cpu/cpufreq/policy{}/scaling_governor".format(
             cpu)

--- a/hardware/tests/samples/lscpu_aarch64
+++ b/hardware/tests/samples/lscpu_aarch64
@@ -1,0 +1,18 @@
+Architecture:        aarch64
+Byte Order:          Little Endian
+CPU(s):              8
+On-line CPU(s) list: 0-7
+Thread(s) per core:  1
+Core(s) per socket:  2
+Socket(s):           4
+NUMA node(s):        1
+Vendor ID:           APM
+Model:               0
+Model name:          X-Gene
+Stepping:            0x0
+BogoMIPS:            100.00
+L1d cache:           unknown size
+L1i cache:           unknown size
+L2 cache:            unknown size
+NUMA node0 CPU(s):   0-7
+Flags:               fp asimd evtstrm cpuid

--- a/hardware/tests/samples/lscpu_ppc64le
+++ b/hardware/tests/samples/lscpu_ppc64le
@@ -1,0 +1,22 @@
+Architecture:        ppc64le
+Byte Order:          Little Endian
+CPU(s):              144
+On-line CPU(s) list: 0-143
+Thread(s) per core:  4
+Core(s) per socket:  18
+Socket(s):           2
+NUMA node(s):        6
+Model:               2.2 (pvr 004e 1202)
+Model name:          POWER9, altivec supported
+CPU max MHz:         3800.0000
+CPU min MHz:         2300.0000
+L1d cache:           32K
+L1i cache:           32K
+L2 cache:            512K
+L3 cache:            10240K
+NUMA node0 CPU(s):   0-71
+NUMA node8 CPU(s):   72-143
+NUMA node252 CPU(s): 
+NUMA node253 CPU(s): 
+NUMA node254 CPU(s): 
+NUMA node255 CPU(s): 

--- a/hardware/tests/samples/lscpux_aarch64
+++ b/hardware/tests/samples/lscpux_aarch64
@@ -1,0 +1,18 @@
+Architecture:        aarch64
+Byte Order:          Little Endian
+CPU(s):              8
+On-line CPU(s) mask: ff
+Thread(s) per core:  1
+Core(s) per socket:  2
+Socket(s):           4
+NUMA node(s):        1
+Vendor ID:           APM
+Model:               0
+Model name:          X-Gene
+Stepping:            0x0
+BogoMIPS:            100.00
+L1d cache:           unknown size
+L1i cache:           unknown size
+L2 cache:            unknown size
+NUMA node0 CPU(s):   ff
+Flags:               fp asimd evtstrm cpuid

--- a/hardware/tests/samples/lscpux_ppc64le
+++ b/hardware/tests/samples/lscpux_ppc64le
@@ -1,0 +1,22 @@
+Architecture:        ppc64le
+Byte Order:          Little Endian
+CPU(s):              144
+On-line CPU(s) mask: ffffffffffffffffffffffffffffffffffff
+Thread(s) per core:  4
+Core(s) per socket:  18
+Socket(s):           2
+NUMA node(s):        6
+Model:               2.2 (pvr 004e 1202)
+Model name:          POWER9, altivec supported
+CPU max MHz:         3800.0000
+CPU min MHz:         2300.0000
+L1d cache:           32K
+L1i cache:           32K
+L2 cache:            512K
+L3 cache:            10240K
+NUMA node0 CPU(s):   ffffffffffffffffff
+NUMA node8 CPU(s):   ffffffffffffffffff000000000000000000
+NUMA node252 CPU(s): 0
+NUMA node253 CPU(s): 0
+NUMA node254 CPU(s): 0
+NUMA node255 CPU(s): 0

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -217,6 +217,135 @@ class TestDetect(unittest.TestCase):
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_os_path_exists.mock_calls)
 
+    @mock.patch('os.path.exists', return_value=False)
+    @mock.patch('hardware.detect_utils.output_lines',
+                side_effect=[
+                    sample('lscpu_aarch64').split('\n'),
+                    sample('lscpux_aarch64').split('\n'),
+                    ('powersave',),
+                    ('powersave',),
+                ]
+                )
+    def test_get_cpus_aarch64(self, mock_output_lines, mock_os_path_exists):
+        self.maxDiff = None
+        hw = []
+        detect.get_cpus(hw)
+        self.assertEqual(hw, [('cpu', 'physical', 'number', 4),
+                              ('cpu', 'physical_0', 'vendor', 'APM'),
+                              ('cpu', 'physical_0', 'product', 'X-Gene'),
+                              ('cpu', 'physical_0', 'cores', 2),
+                              ('cpu', 'physical_0', 'threads', 2),
+                              ('cpu', 'physical_0', 'model', 0),
+                              ('cpu', 'physical_0', 'stepping', 0),
+                              ('cpu', 'physical_0', 'l1d cache', 'unknown size'),
+                              ('cpu', 'physical_0', 'l1i cache', 'unknown size'),
+                              ('cpu', 'physical_0', 'l2 cache', 'unknown size'),
+                              ('cpu', 'physical_0', 'flags', 'fp asimd evtstrm cpuid'),
+                              ('cpu', 'physical_1', 'vendor', 'APM'),
+                              ('cpu', 'physical_1', 'product', 'X-Gene'),
+                              ('cpu', 'physical_1', 'cores', 2),
+                              ('cpu', 'physical_1', 'threads', 2),
+                              ('cpu', 'physical_1', 'model', 0),
+                              ('cpu', 'physical_1', 'stepping', 0),
+                              ('cpu', 'physical_1', 'l1d cache', 'unknown size'),
+                              ('cpu', 'physical_1', 'l1i cache', 'unknown size'),
+                              ('cpu', 'physical_1', 'l2 cache', 'unknown size'),
+                              ('cpu', 'physical_1', 'flags', 'fp asimd evtstrm cpuid'),
+                              ('cpu', 'physical_2', 'vendor', 'APM'),
+                              ('cpu', 'physical_2', 'product', 'X-Gene'),
+                              ('cpu', 'physical_2', 'cores', 2),
+                              ('cpu', 'physical_2', 'threads', 2),
+                              ('cpu', 'physical_2', 'model', 0),
+                              ('cpu', 'physical_2', 'stepping', 0),
+                              ('cpu', 'physical_2', 'l1d cache', 'unknown size'),
+                              ('cpu', 'physical_2', 'l1i cache', 'unknown size'),
+                              ('cpu', 'physical_2', 'l2 cache', 'unknown size'),
+                              ('cpu', 'physical_2', 'flags', 'fp asimd evtstrm cpuid'),
+                              ('cpu', 'physical_3', 'vendor', 'APM'),
+                              ('cpu', 'physical_3', 'product', 'X-Gene'),
+                              ('cpu', 'physical_3', 'cores', 2),
+                              ('cpu', 'physical_3', 'threads', 2),
+                              ('cpu', 'physical_3', 'model', 0),
+                              ('cpu', 'physical_3', 'stepping', 0),
+                              ('cpu', 'physical_3', 'l1d cache', 'unknown size'),
+                              ('cpu', 'physical_3', 'l1i cache', 'unknown size'),
+                              ('cpu', 'physical_3', 'l2 cache', 'unknown size'),
+                              ('cpu', 'physical_3', 'flags', 'fp asimd evtstrm cpuid'),
+                              ('cpu', 'logical', 'number', 8),
+                              ('numa', 'nodes', 'count', 1),
+                              ('numa', 'node_0', 'cpu_count', 8),
+                              ('numa', 'node_0', 'cpu_mask', 'ff')])
+        calls = []
+        # Once per socket
+        for i in range(4):
+            calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
+        # Once per processor
+        for i in range(8):
+            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
+                 (i))
+            calls.append(mock.call(f))
+        # NOTE(tonyb): We can't use assert_has_calls() because it's too
+        # permissive.  We want an exact match
+        self.assertEqual(calls, mock_os_path_exists.mock_calls)
+
+    @mock.patch('os.path.exists', return_value=False)
+    @mock.patch('hardware.detect_utils.output_lines',
+                side_effect=[
+                    sample('lscpu_ppc64le').split('\n'),
+                    sample('lscpux_ppc64le').split('\n'),
+                ]
+                )
+    def test_get_cpus_ppc64le(self, mock_output_lines, mock_os_path_exists):
+        hw = []
+        detect.get_cpus(hw)
+        self.assertEqual(hw, [('cpu', 'physical', 'number', 2),
+                              ('cpu', 'physical_0', 'product', 'POWER9, altivec supported'),
+                              ('cpu', 'physical_0', 'cores', 18),
+                              ('cpu', 'physical_0', 'threads', 72),
+                              ('cpu', 'physical_0', 'model', '2.2 (pvr 004e 1202)'),
+                              ('cpu', 'physical_0', 'l1d cache', '32K'),
+                              ('cpu', 'physical_0', 'l1i cache', '32K'),
+                              ('cpu', 'physical_0', 'l2 cache', '512K'),
+                              ('cpu', 'physical_0', 'l3 cache', '10240K'),
+                              ('cpu', 'physical_0', 'min_Mhz', 2300.0),
+                              ('cpu', 'physical_0', 'max_Mhz', 3800.0),
+                              ('cpu', 'physical_1', 'product', 'POWER9, altivec supported'),
+                              ('cpu', 'physical_1', 'cores', 18),
+                              ('cpu', 'physical_1', 'threads', 72),
+                              ('cpu', 'physical_1', 'model', '2.2 (pvr 004e 1202)'),
+                              ('cpu', 'physical_1', 'l1d cache', '32K'),
+                              ('cpu', 'physical_1', 'l1i cache', '32K'),
+                              ('cpu', 'physical_1', 'l2 cache', '512K'),
+                              ('cpu', 'physical_1', 'l3 cache', '10240K'),
+                              ('cpu', 'physical_1', 'min_Mhz', 2300.0),
+                              ('cpu', 'physical_1', 'max_Mhz', 3800.0),
+                              ('cpu', 'logical', 'number', 144),
+                              ('numa', 'nodes', 'count', 6),
+                              ('numa', 'node_0', 'cpu_count', 72),
+                              ('numa', 'node_0', 'cpu_mask', 'ffffffffffffffffff'),
+                              ('numa', 'node_8', 'cpu_count', 72),
+                              ('numa', 'node_8', 'cpu_mask', 'ffffffffffffffffff000000000000000000'),
+                              ('numa', 'node_252', 'cpu_count', 0),
+                              ('numa', 'node_252', 'cpu_mask', '0'),
+                              ('numa', 'node_253', 'cpu_count', 0),
+                              ('numa', 'node_253', 'cpu_mask', '0'),
+                              ('numa', 'node_254', 'cpu_count', 0),
+                              ('numa', 'node_254', 'cpu_mask', '0'),
+                              ('numa', 'node_255', 'cpu_count', 0),
+                              ('numa', 'node_255', 'cpu_mask', '0')])
+        calls = []
+        # Once per socket
+        for i in range(2):
+            calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
+        # Once per processor
+        for i in range(144):
+            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
+                 (i))
+            calls.append(mock.call(f))
+        # NOTE(tonyb): We can't use assert_has_calls() because it's too
+        # permissive.  We want an exact match
+        self.assertEqual(calls, mock_os_path_exists.mock_calls)
+
     def test_parse_dmesg(self):
         hw = []
         detect.parse_dmesg(hw, sample('dmesg'))


### PR DESCRIPTION
Certain lscpu keys don't make sense on ppc64le (e.g Vendor, CPU Family,
Stepping) and others are strings rather than ints (e.g. Model).

Handle these difference.

While we're looking at this NUMA nodes are represented differently on
ppc64le systems in that they are sparse and may have no CPUs allocated.