### PR TITLE
Split lscpu output on first colon occurrence only

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -665,16 +665,17 @@ def get_cpus(hw_lst):
 
     for line in output:
         if ':' in line:
-            item, value = line.split(':')
+            item, value = line.split(':', 1)
             lscpu[item.strip(':')] = value.strip()
 
     # Extracting lspcu -x information
+    # Use hexadecimal masks for CPU sets
     lscpux = {}
     output = detect_utils.output_lines('LANG=en_US.UTF-8 lscpu -x')
 
     for line in output:
         if ':' in line:
-            item, value = line.split(':')
+            item, value = line.split(':', 1)
             lscpux[item.strip(':')] = value.strip()
 
     hw_lst.append(("cpu", "physical", "number", int(lscpu["Socket(s)"])))

--- a/hardware/tests/samples/lscpu
+++ b/hardware/tests/samples/lscpu
@@ -7,10 +7,10 @@ Thread(s) per core:    2
 Core(s) per socket:    24
 Socket(s):             2
 NUMA node(s):          8
-Vendor ID:             AuthenticAMD
+Vendor ID:             FakeAMD
 CPU family:            23
 Model:                 1
-Model name:            AMD EPYC 7451 24-Core Processor
+Model name:            AMD: EPYC 7451 24-Core Processor
 Stepping:              2
 CPU MHz:               1197.549
 CPU max MHz:           2300.0000

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -59,9 +59,9 @@ class TestDetect(unittest.TestCase):
         detect.get_cpus(hw)
 
         self.assertEqual(hw, [('cpu', 'physical', 'number', 2),
-                              ('cpu', 'physical_0', 'vendor', 'AuthenticAMD'),
+                              ('cpu', 'physical_0', 'vendor', 'FakeAMD'),
                               ('cpu', 'physical_0', 'product',
-                               'AMD EPYC 7451 24-Core Processor'),
+                               'AMD: EPYC 7451 24-Core Processor'),
                               ('cpu', 'physical_0', 'cores', 24),
                               ('cpu', 'physical_0', 'threads', 48),
                               ('cpu', 'physical_0', 'family', 23),
@@ -93,9 +93,9 @@ class TestDetect(unittest.TestCase):
                                'flushbyasid decodeassists pausefilter '
                                'pfthreshold avic v_vmsave_vmload vgif '
                                'overflow_recov succor smca'),
-                              ('cpu', 'physical_1', 'vendor', 'AuthenticAMD'),
+                              ('cpu', 'physical_1', 'vendor', 'FakeAMD'),
                               ('cpu', 'physical_1', 'product',
-                               'AMD EPYC 7451 24-Core Processor'),
+                               'AMD: EPYC 7451 24-Core Processor'),
                               ('cpu', 'physical_1', 'cores', 24),
                               ('cpu', 'physical_1', 'threads', 48),
                               ('cpu', 'physical_1', 'family', 23),


### PR DESCRIPTION
If the value of an entry detected by lscpu contains a colon ':'
the execution fails with ValueError: too many values to unpack
exception.
This patch prevents that situation, splitting each line after the
first occurrence of the colon ':' symbol only.