### PR TITLE
Call dmesg inside its parsing function

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -861,7 +861,10 @@ def parse_ahci(hrdw, words):
         hrdw.append(('ahci', words[1], "flags", flags.strip()))
 
 
-def parse_dmesg(hrdw, output):
+def parse_dmesg(hrdw):
+    """Run dmesg and parse the output."""
+
+    _, output = cmd("dmesg")
     for line in output.split('\n'):
         words = line.strip().split(" ")
 
@@ -930,8 +933,7 @@ def main():
     detect_utils.get_ddr_timing(hrdw)
     detect_utils.ipmi_sdr(hrdw)
     detect_rtc_clock(hrdw)
-    _, output = cmd("dmesg")
-    parse_dmesg(hrdw, output)
+    parse_dmesg(hrdw)
     bios_hp.dump_hp_bios(hrdw)
 
     if args.benchmark:

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -346,9 +346,12 @@ class TestDetect(unittest.TestCase):
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_os_path_exists.mock_calls)
 
-    def test_parse_dmesg(self):
+    @mock.patch('hardware.detect.cmd',
+                return_value=(0, sample('dmesg')),
+                autospec=True)
+    def test_parse_dmesg(self, mock_cmd):
         hw = []
-        detect.parse_dmesg(hw, sample('dmesg'))
+        detect.parse_dmesg(hw)
         self.assertEqual(hw, [('ahci', '0000:00:1f.2:', 'flags',
                                '64bit apst clo ems led '
                                'ncq part pio slum sntf')])


### PR DESCRIPTION
We call dmesg directly inside its parsing function instead of
passing the huge output as parameter to the function.
This helps also in keeping consinstency in case of refactoring.