### PR TITLE
[Bugzilla 1729237] Fix benchmark output for disks

### DIFF
--- a/hardware/benchmark/disk.py
+++ b/hardware/benchmark/disk.py
@@ -23,6 +23,8 @@ import re
 import subprocess
 import sys
 
+import six
+
 
 # NOTE(lucasagomes): The amount of time a specified workload will run before
 # logging any performance numbers. Useful for letting performance settle
@@ -41,6 +43,8 @@ def is_booted_storage_device(disk):
     grep_cmd = subprocess.Popen(cmdline,
                                 shell=True, stdout=subprocess.PIPE)
     for booted_disk in grep_cmd.stdout:
+        if isinstance(booted_disk, six.binary_type):
+            booted_disk = booted_disk.decode(errors='ignore')
         booted_disk = booted_disk.rstrip('\n').strip()
         if booted_disk == disk:
             return True
@@ -89,6 +93,8 @@ def run_fio(hw_lst, disks_list, mode, io_size, time, rampup_time):
                                shell=True, stdout=subprocess.PIPE)
     current_disk = ''
     for line in fio_cmd.stdout:
+        if isinstance(line, six.binary_type):
+            line = line.decode(errors='ignore')
         if ('MYJOB-' in line) and ('pid=' in line):
             # MYJOB-sda: (groupid=0, jobs=1): err= 0: pid=23652: Mon Sep  9
             # 16:21:42 2013

--- a/hardware/tests/test_benchmark_disk.py
+++ b/hardware/tests/test_benchmark_disk.py
@@ -24,7 +24,24 @@ from hardware.benchmark import disk
 
 
 FIO_OUTPUT_READ = """MYJOB-fake-disk: (groupid=0, jobs=1): err= 0: pid=5427:
-  read : io=123456KB, bw=123456KB/s, iops=123, runt= 10304msec""".splitlines()
+  read : io=123456KB, bw=123456KB/s, iops=123, runt= 10304msec"""
+
+DISK_PERF_EXPECTED = [
+    ('disk', 'fake-disk', 'size', '10'),
+    ('disk', 'fake-disk2', 'size', '15'),
+    ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
+    ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
+    ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
+    ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
+    ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
+    ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
+    ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
+    ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
+    ('disk', 'fake-disk', 'simultaneous_read_1M_KBps', '123456'),
+    ('disk', 'fake-disk', 'simultaneous_read_1M_IOps', '123'),
+    ('disk', 'fake-disk', 'simultaneous_randread_4k_KBps', '123456'),
+    ('disk', 'fake-disk', 'simultaneous_randread_4k_IOps', '123'),
+]
 
 
 @mock.patch.object(subprocess, 'Popen')
@@ -35,38 +52,28 @@ class TestBenchmarkDisk(unittest.TestCase):
         self.hw_data = [('disk', 'fake-disk', 'size', '10'),
                         ('disk', 'fake-disk2', 'size', '15')]
 
-    def test_disk_perf(self, mock_popen):
-        mock_popen.return_value = mock.Mock(stdout=FIO_OUTPUT_READ)
+    def test_disk_perf_text(self, mock_popen):
+        mock_popen.return_value = mock.Mock(
+            stdout=FIO_OUTPUT_READ.splitlines())
         disk.disk_perf(self.hw_data)
+        self.assertEqual(sorted(DISK_PERF_EXPECTED), sorted(self.hw_data))
 
-        expected = [
-            ('disk', 'fake-disk', 'size', '10'),
-            ('disk', 'fake-disk2', 'size', '15'),
-            ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
-            ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
-            ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
-            ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
-            ('disk', 'fake-disk', 'standalone_read_1M_KBps', '123456'),
-            ('disk', 'fake-disk', 'standalone_read_1M_IOps', '123'),
-            ('disk', 'fake-disk', 'standalone_randread_4k_KBps', '123456'),
-            ('disk', 'fake-disk', 'standalone_randread_4k_IOps', '123'),
-            ('disk', 'fake-disk', 'simultaneous_read_1M_KBps', '123456'),
-            ('disk', 'fake-disk', 'simultaneous_read_1M_IOps', '123'),
-            ('disk', 'fake-disk', 'simultaneous_randread_4k_KBps', '123456'),
-            ('disk', 'fake-disk', 'simultaneous_randread_4k_IOps', '123')
-        ]
-        self.assertEqual(sorted(expected), sorted(self.hw_data))
+    def test_disk_perf_bytes(self, mock_popen):
+        mock_popen.return_value = mock.Mock(
+            stdout=FIO_OUTPUT_READ.encode().splitlines())
+        disk.disk_perf(self.hw_data)
+        self.assertEqual(sorted(DISK_PERF_EXPECTED), sorted(self.hw_data))
 
     def test_get_disks_name(self, mock_popen):
         result = disk.get_disks_name(self.hw_data)
         self.assertEqual(sorted(['fake-disk', 'fake-disk2']), sorted(result))
 
     def test_run_fio(self, mock_popen):
-        mock_popen.return_value = mock.Mock(stdout=FIO_OUTPUT_READ)
+        mock_popen.return_value = mock.Mock(
+            stdout=FIO_OUTPUT_READ.splitlines())
         hw_data = []
         disks_list = ['fake-disk', 'fake-disk2']
         disk.run_fio(hw_data, disks_list, "read", 123, 10, 5)
-
         self.assertEqual(sorted(
             [('disk', 'fake-disk', 'simultaneous_read_123_KBps', '123456'),
              ('disk', 'fake-disk', 'simultaneous_read_123_IOps', '123')]),


### PR DESCRIPTION
when running the benchmark script with python 3, the command
output is bytecode and not str.
This patch fixes the parsing converting the output in the
appropriate format according to Python version used.