### PR TITLE
Improve resiliency to failure

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -735,7 +735,10 @@ def get_cpus(hw_lst):
             hw_lst.append(('cpu', ltag, "governor", value))
 
     # Extracting numa nodes
-    hw_lst.append(('numa', 'nodes', 'count', int(lscpu['NUMA node(s)'])))
+    try:
+        hw_lst.append(('numa', 'nodes', 'count', int(lscpu['NUMA node(s)'])))
+    except KeyError:
+        pass
 
     # Allow for sparse numa nodes.
     numa_nodes = []

--- a/hardware/rtc.py
+++ b/hardware/rtc.py
@@ -26,15 +26,17 @@ LOG = logging.getLogger('hardware.rtc')
 
 def get_rtc():
     cmd = ['timedatectl', 'status', '--no-pager']
-    stdout = check_output(cmd).decode("utf-8")
+    try:
+        stdout = check_output(cmd).decode("utf-8")
+    except OSError:
+        LOG.warning('Unable to determine RTC timezone (no timedatectl)')
+        return 'unknown'
     if stdout:
         match = re.search(r'RTC in local TZ: ([a-z]+)$', stdout)
         if match:
             LOG.info('Is RTC set to UTC: %s' % match.group(1))
             return match.group(1)
-
         LOG.warning('Unable to determine RTC timezone (no match)')
     else:
         LOG.warning('Unable to determine RTC timezone (no output)')
-
     return 'unknown'


### PR DESCRIPTION
hardware-detect can fail under these two cases:
1) if 'lscpu' doesn't return a 'NUMA node(s)' key,
2) if 'timedatectl' isn't available.
These have been observed using 'hardware' in tinyipa, part of the openstack ironic-python-agent-builder repository.

This patch catches these errors and allows detect-hardware to exit successfully despite these error conditions.