### PR TITLE
Rename FakeAMD back to AuthenticAMD

### DIFF
--- a/hardware/tests/results/detect_results.py
+++ b/hardware/tests/results/detect_results.py
@@ -12,7 +12,7 @@
 
 
 GET_CPUS_RESULT = [('cpu', 'physical', 'number', 2),
-                   ('cpu', 'physical_0', 'vendor', 'FakeAMD'),
+                   ('cpu', 'physical_0', 'vendor', 'AuthenticAMD'),
                    ('cpu', 'physical_0', 'product',
                    'AMD: EPYC 7451 24-Core Processor'),
                    ('cpu', 'physical_0', 'cores', 24),
@@ -46,7 +46,7 @@ GET_CPUS_RESULT = [('cpu', 'physical', 'number', 2),
                     'flushbyasid decodeassists pausefilter '
                     'pfthreshold avic v_vmsave_vmload vgif '
                     'overflow_recov succor smca'),
-                   ('cpu', 'physical_1', 'vendor', 'FakeAMD'),
+                   ('cpu', 'physical_1', 'vendor', 'AuthenticAMD'),
                    ('cpu', 'physical_1', 'product',
                    'AMD: EPYC 7451 24-Core Processor'),
                    ('cpu', 'physical_1', 'cores', 24),

--- a/hardware/tests/samples/lscpu
+++ b/hardware/tests/samples/lscpu
@@ -7,7 +7,7 @@ Thread(s) per core:    2
 Core(s) per socket:    24
 Socket(s):             2
 NUMA node(s):          8
-Vendor ID:             FakeAMD
+Vendor ID:             AuthenticAMD
 CPU family:            23
 Model:                 1
 Model name:            AMD: EPYC 7451 24-Core Processor

--- a/hardware/tests/samples/lscpux
+++ b/hardware/tests/samples/lscpux
@@ -7,7 +7,7 @@ Thread(s) per core:    2
 Core(s) per socket:    24
 Socket(s):             2
 NUMA node(s):          8
-Vendor ID:             FakeAMD
+Vendor ID:             AuthenticAMD
 CPU family:            23
 Model:                 1
 Model name:            AMD: EPYC 7451 24-Core Processor


### PR DESCRIPTION
There was no reason to change that, and it's contradictive from
the trademark point of view.