### PR TITLE
Enabling docs testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TOX_ENV=pep8
   - TOX_ENV=pylint
   - TOX_ENV=cover
+  - TOX_ENV=docs
 install:
   - pip install tox
 script:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx!=1.6.6,!=1.6.7,>=1.6.2,<2.0.0;python_version=='2.7' # BSD
+sphinx!=1.6.6,!=1.6.7,!=2.1.0,>=1.6.2;python_version>='3.4' # BSD

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,8 +22,6 @@ sys.path.insert(0, os.path.abspath('../..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
-    #'sphinx.ext.intersphinx',
-    'oslosphinx'
 ]
 
 # autodoc generation is a bit aggressive and a nuisance when doing heavy

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,1 +1,0 @@
-oslosphinx # Apache-2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 
 pbr>=1.0 # Apache-2.0
 six # MIT
-Babel>=1.3 # BSD
 ipaddress # PSF
 netaddr # BSD
 pexpect # ISC

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,9 +7,8 @@ hacking>=0.9.2,<0.10 # Apache-2.0
 coverage>=3.6 # Apache-2.0
 discover # BSD
 python-subunit # Apache-2.0/BSD
-sphinx>=1.1.2 # BSD
-oslosphinx # Apache-2.0
 stestr>=2.0.0 # Apache-2.0
 testtools>=0.9.34 # MIT
 pylint>=1.4.2 # GPL
-mock # BSD
+mock>=3.0.0 # BSD
+Babel!=2.4.0,>=2.3.4 # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,9 @@ whitelist_externals =
 commands = bash -c "{toxinidir}/tools/check-pylint-score.sh 8.91 -j $(nproc) --rcfile {toxinidir}/tools/pylintrc $(find {toxinidir}/hardware -name '*.py'|grep -v '^{toxinidir}/hardware/tests')"
 
 [testenv:docs]
-deps = -r{toxinidir}/requirements-doc.txt
-commands = python setup.py build_sphinx
+basepython = python3
+deps = -r{toxinidir}/doc/requirements.txt
+commands = sphinx-build -b html -W doc/source doc/build/html
 
 [flake8]
 # H803 skipped on purpose per list discussion.


### PR DESCRIPTION
Reviewed doc requirements and configuration.
Removed unmaintained oslosphinx in preparation of moving to
openstackdocstheme.
Removed general Babel req and added to testing.
Fixed sphinx, Babel and mock version requirements to align with
latest Python 3.x versions.