### PR TITLE
Drop Python 3.5 in favor of Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ sudo: false
 dist: xenial
 python:
   - '2.7'
-  - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
 env:
   - TOX_ENV=unit
   - TOX_ENV=pep8

--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -71,7 +71,8 @@ def _generate_values(pattern, prefix=_PREFIX):
         for elt in pattern:
             yield elt
     elif isinstance(pattern, dict):
-        for key, entry in pattern.items():
+        pattern_copy = pattern.copy()
+        for key, entry in pattern_copy.items():
             if not prefix or key[0] == prefix:
                 if prefix:
                     pattern[key[1:]] = _generate_values(entry)
@@ -152,7 +153,8 @@ def generate(model, prefix=_PREFIX):
     result = []
     yielded = {}
     yielded.update(model)
-    for key, value in yielded.items():
+    yielded_copy = yielded.copy()
+    for key, value in yielded_copy.items():
         if not prefix or key[0] == prefix:
             if prefix:
                 yielded[key[1:]] = _generate_values(value, prefix)

--- a/hardware/matcher.py
+++ b/hardware/matcher.py
@@ -235,7 +235,7 @@ Store variables starting with a $ in <arr>. Variables starting with
                     sys.stderr.write('new var: %s %s\n' % (arr, line))
 
     # Manage $$ variables
-    for key in arr:
+    for key in list(arr):
         if key[0] == '$':
             nkey = key[1:]
             arr[nkey] = arr[key]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py35,py36,py37,py27,pep8,pylint,cover
+envlist = py27,py36,py37,py38,pep8,pylint,cover,docs
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This patch drops support and testing for Python 3.5 in favor of
Python 3.8
Also adding docs env to tox.ini as follow-up to #110