### PR TITLE
Use bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - bc
     - findutils
 sudo: false
-dist: xenial
+dist: bionic
 python:
   - '2.7'
   - '3.6'


### PR DESCRIPTION
Looks like travis has a good support for bionic now, let's drop
xenial and use bionic instead.

This patch depends on #112