### PR TITLE
Stop supporting Python 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 sudo: false
 dist: bionic
 python:
-  - '2.7'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,1 @@
-sphinx!=1.6.6,!=1.6.7,>=1.6.2,<2.0.0;python_version=='2.7' # BSD
 sphinx!=1.6.6,!=1.6.7,!=2.1.0,>=1.6.2;python_version>='3.4' # BSD

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 minversion = 1.6
-envlist = py27,py36,py37,py38,pep8,pylint,cover,docs
+envlist = py36,py37,py38,pep8,pylint,cover,docs
 skipsdist = True
 
 [testenv]
+basepython = python3
 setenv =
     VIRTUAL_ENV={envdir}
     PYTHONDONTWRITEBYTECODE=1
@@ -19,18 +20,15 @@ commands =
     stestr run {posargs}
 
 [testenv:pep8]
-basepython = python3
 commands = flake8
 
 [testenv:venv]
-basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = {posargs}
 
 [testenv:cover]
-basepython = python3
 setenv =
     VIRTUAL_ENV={envdir}
     PYTHON=coverage run --source hardware --omit='*tests*' --parallel-mode
@@ -43,7 +41,6 @@ commands =
     coverage xml -o cover/coverage.xml --omit='*tests*'
 
 [testenv:pylint]
-basepython = python3
 whitelist_externals =
     /bin/sh
     /bin/bash
@@ -51,14 +48,12 @@ whitelist_externals =
 commands = bash -c "{toxinidir}/tools/check-pylint-score.sh 8.91 -j $(nproc) --rcfile {toxinidir}/tools/pylintrc $(find {toxinidir}/hardware -name '*.py'|grep -v '^{toxinidir}/hardware/tests')"
 
 [testenv:docs]
-basepython = python3
 deps = -r{toxinidir}/doc/requirements.txt
 commands = sphinx-build -b html -W doc/source doc/build/html
 
 [flake8]
 # H803 skipped on purpose per list discussion.
 # E123, E125 skipped as they are invalid PEP-8.
-
 show-source = True
 ignore = E123,E125,H803,H302
 builtins = _


### PR DESCRIPTION
With this patch we stop explicit support for Python 2.x.
From now on, all tests are executed with Python 3.x only; future
versions of the code won't guarantee working with versions prior
to 3.6 of Python.