### PR TITLE
Use correct python version for tox based on env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-minversion = 1.6
+minversion = 3.1.0
 envlist = py36,py37,py38,pep8,pylint,cover,docs
 skipsdist = True
+ignore_basepython_conflict=true
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Enforce the correct version based on tox environment adding the
option ignore_basepython_conflict available since tox 3.1.0 [0].

[0] https://tox.readthedocs.io/en/latest/config.html#conf-ignore_basepython_conflict