### PR TITLE
Stop using six library

### DIFF
--- a/hardware/benchmark/cpu.py
+++ b/hardware/benchmark/cpu.py
@@ -21,8 +21,6 @@ Benchmark CPU functions.
 import subprocess
 import sys
 
-import six
-
 from hardware.benchmark import utils
 
 
@@ -51,8 +49,7 @@ def run_sysbench_cpu(hw_lst, max_time, cpu_count, processor_num=None):
     sysbench_cmd = subprocess.Popen(cmds, shell=True, stdout=subprocess.PIPE)
 
     for line in sysbench_cmd.stdout:
-        if isinstance(line, six.binary_type):
-            line = line.decode()
+        line = line.decode()
         if "total number of events" in line:
             line_ = line.rstrip('\n').replace(' ', '')
             _, perf = line_.split(':')

--- a/hardware/benchmark/disk.py
+++ b/hardware/benchmark/disk.py
@@ -23,8 +23,6 @@ import re
 import subprocess
 import sys
 
-import six
-
 
 # NOTE(lucasagomes): The amount of time a specified workload will run before
 # logging any performance numbers. Useful for letting performance settle
@@ -44,8 +42,7 @@ def is_booted_storage_device(disk):
     grep_cmd = subprocess.Popen(cmdline,
                                 shell=True, stdout=subprocess.PIPE)
     for booted_disk in grep_cmd.stdout:
-        if isinstance(booted_disk, six.binary_type):
-            booted_disk = booted_disk.decode(errors='ignore')
+        booted_disk = booted_disk.decode(errors='ignore')
         booted_disk = booted_disk.rstrip('\n').strip()
         if booted_disk == disk:
             return True
@@ -94,8 +91,7 @@ def run_fio(hw_lst, disks_list, mode, io_size, time, rampup_time):
                                shell=True, stdout=subprocess.PIPE)
     current_disk = ''
     for line in fio_cmd.stdout:
-        if isinstance(line, six.binary_type):
-            line = line.decode(errors='ignore')
+        line = line.decode(errors='ignore')
         if ('MYJOB-' in line) and ('pid=' in line):
             # MYJOB-sda: (groupid=0, jobs=1): err= 0: pid=23652: Mon Sep  9
             # 16:21:42 2013

--- a/hardware/benchmark/mem.py
+++ b/hardware/benchmark/mem.py
@@ -22,8 +22,6 @@ import re
 import subprocess
 import sys
 
-import six
-
 from hardware.benchmark import utils
 
 
@@ -90,8 +88,7 @@ def run_sysbench_memory_threaded(hw_lst, max_time, block_size, cpu_count,
                                     shell=True, stdout=subprocess.PIPE)
 
     for line in sysbench_cmd.stdout:
-        if isinstance(line, six.binary_type):
-            line = line.decode()
+        line = line.decode()
         if "transferred" in line:
             _, right = line.rstrip('\n').replace(' ', '').split('(')
             perf, _ = right.split('.')
@@ -129,8 +126,7 @@ def run_sysbench_memory_forked(hw_lst, max_time, block_size, cpu_count):
     process = subprocess.Popen(
         sysbench_cmd, shell=True, stdout=subprocess.PIPE)
     for line in process.stdout:
-        if isinstance(line, six.binary_type):
-            line = line.decode()
+        line = line.decode()
         if "transferred" in line:
             _, right = line.rstrip('\n').replace(' ', '').split('(')
             perf, _ = right.split('.')

--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -18,17 +18,10 @@
 """Generate range of values according to a model."""
 
 import re
-import sys
 import types
-
-from six.moves import range
 
 
 _PREFIX = None
-
-
-if sys.version_info.major:
-    xrange = range
 
 
 def _generate_range(num_range):

--- a/hardware/smart_utils.py
+++ b/hardware/smart_utils.py
@@ -14,15 +14,11 @@ import os
 import subprocess
 import sys
 
-import six
-
 from hardware import smart_utils_info
 
 
 def _parse_line(line):
-    line = line.strip()
-    if isinstance(line, six.binary_type):
-        line = line.decode(errors='ignore')
+    line = line.strip().decode(errors='ignore')
     return line
 
 
@@ -280,11 +276,8 @@ def read_smart_nvme(hwlst, device_name):
             shell=True, stdout=subprocess.PIPE)
 
         for line in sdparm_cmd.stdout:
-            line = line.strip()
-            if isinstance(line, six.binary_type):
-                line = line.decode(errors='ignore')
-            for disk_info, info_tag in six.iteritems(
-                    smart_utils_info.NVME_INFOS):
+            line = line.strip().decode(errors='ignore')
+            for disk_info, info_tag in smart_utils_info.NVME_INFOS.items():
                 read_smart_field(hwlst, line, device_name, disk_info, info_tag)
         return hwlst
 

--- a/hardware/tests/test_benchmark_cpu.py
+++ b/hardware/tests/test_benchmark_cpu.py
@@ -99,16 +99,3 @@ class TestBenchmarkCPU(unittest.TestCase):
                                            '--cpu-max-prime=15000 run',
                                            shell=True, stdout=subprocess.PIPE)
         self.assertEqual([('cpu', 'logical', 'loops_per_sec', '123')], hw_data)
-
-    def test_run_sysbench_cpu_text(self, mock_popen, mock_cpu_socket,
-                                   mock_search_info):
-        mock_popen.return_value = mock.Mock(
-            stdout=SYSBENCH_OUTPUT.splitlines())
-        hw_data = []
-        cpu.run_sysbench_cpu(hw_data, 10, 1)
-        mock_popen.assert_called_once_with(' sysbench --max-time=10 '
-                                           '--max-requests=10000000 '
-                                           '--num-threads=1 --test=cpu '
-                                           '--cpu-max-prime=15000 run',
-                                           shell=True, stdout=subprocess.PIPE)
-        self.assertEqual([('cpu', 'logical', 'loops_per_sec', '123')], hw_data)

--- a/hardware/tests/test_benchmark_disk.py
+++ b/hardware/tests/test_benchmark_disk.py
@@ -52,12 +52,6 @@ class TestBenchmarkDisk(unittest.TestCase):
         self.hw_data = [('disk', 'fake-disk', 'size', '10'),
                         ('disk', 'fake-disk2', 'size', '15')]
 
-    def test_disk_perf_text(self, mock_popen):
-        mock_popen.return_value = mock.Mock(
-            stdout=FIO_OUTPUT_READ.splitlines())
-        disk.disk_perf(self.hw_data)
-        self.assertEqual(sorted(DISK_PERF_EXPECTED), sorted(self.hw_data))
-
     def test_disk_perf_bytes(self, mock_popen):
         mock_popen.return_value = mock.Mock(
             stdout=FIO_OUTPUT_READ.encode().splitlines())
@@ -70,7 +64,7 @@ class TestBenchmarkDisk(unittest.TestCase):
 
     def test_run_fio(self, mock_popen):
         mock_popen.return_value = mock.Mock(
-            stdout=FIO_OUTPUT_READ.splitlines())
+            stdout=FIO_OUTPUT_READ.encode().splitlines())
         hw_data = []
         disks_list = ['fake-disk', 'fake-disk2']
         disk.run_fio(hw_data, disks_list, "read", 123, 10, 5)

--- a/hardware/tests/test_benchmark_mem.py
+++ b/hardware/tests/test_benchmark_mem.py
@@ -98,17 +98,6 @@ class TestBenchmarkMem(unittest.TestCase):
         expected = EXPECTED_RESULT
         self.assertEqual(sorted(expected), sorted(self.hw_data))
 
-    def test_mem_perf_text(self, mock_popen, mock_cpu_socket,
-                           mock_get_memory):
-        mock_get_memory.return_value = 123456789012
-        mock_popen.return_value = mock.Mock(
-            stdout=SYSBENCH_OUTPUT.splitlines())
-        mock_cpu_socket.return_value = range(2)
-        mem.mem_perf(self.hw_data)
-
-        expected = EXPECTED_RESULT
-        self.assertEqual(sorted(expected), sorted(self.hw_data))
-
     def test_check_mem_size(self, mock_popen, mock_cpu_socket,
                             mock_get_memory):
         block_size_list = ('1K', '4K', '1M', '16M', '128M', '1G', '2G')
@@ -122,17 +111,6 @@ class TestBenchmarkMem(unittest.TestCase):
         for block_size in block_size_list:
             self.assertFalse(mem.check_mem_size(block_size, 2))
 
-    def test_run_sysbench_memory_forked_text(self, mock_popen, mock_cpu_socket,
-                                             mock_get_memory):
-        mock_get_memory.return_value = 123456789012
-        mock_popen.return_value = mock.Mock(
-            stdout=SYSBENCH_OUTPUT.splitlines())
-
-        hw_data = []
-        mem.run_sysbench_memory_forked(hw_data, 10, '1K', 2)
-        self.assertEqual([('cpu', 'logical', 'forked_bandwidth_1K', '382')],
-                         hw_data)
-
     def test_run_sysbench_memory_forked_bytes(self, mock_popen,
                                               mock_cpu_socket,
                                               mock_get_memory):
@@ -143,18 +121,6 @@ class TestBenchmarkMem(unittest.TestCase):
         hw_data = []
         mem.run_sysbench_memory_forked(hw_data, 10, '1K', 2)
         self.assertEqual([('cpu', 'logical', 'forked_bandwidth_1K', '382')],
-                         hw_data)
-
-    def test_run_sysbench_memory_threaded_text(self, mock_popen,
-                                               mock_cpu_socket,
-                                               mock_get_memory):
-        mock_get_memory.return_value = 123456789012
-        mock_popen.return_value = mock.Mock(
-            stdout=SYSBENCH_OUTPUT.splitlines())
-
-        hw_data = []
-        mem.run_sysbench_memory_threaded(hw_data, 10, '1K', 2)
-        self.assertEqual([('cpu', 'logical', 'threaded_bandwidth_1K', '382')],
                          hw_data)
 
     def test_run_sysbench_memory_threaded_bytes(self, mock_popen,

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -303,7 +303,7 @@ class TestDetect(unittest.TestCase):
     def test_get_uuid_ppc64le_ok_generate(self, mock_access, mock_uname):
         expected_uuid = 'a2724b67-c27e-5e5f-aa2b-3089a2bd8f41'
         fileobj = mock.mock_open(read_data=expected_uuid)
-        with mock.patch('six.moves.builtins.open', fileobj, create=True):
+        with mock.patch('builtins.open', fileobj, create=True):
             uuid = detect.get_uuid([])
         self.assertEqual(expected_uuid, uuid)
 

--- a/hardware/tests/test_smart_utils.py
+++ b/hardware/tests/test_smart_utils.py
@@ -82,7 +82,7 @@ class TestSmartUtils(unittest.TestCase):
     @mock.patch.object(subprocess, 'Popen')
     def test_read_smart_scsi(self, mock_popen):
         hwlst = []
-        fake_output = sample('smartctl_scsi').splitlines()
+        fake_output = sample('smartctl_scsi', mode='rb').splitlines()
         mock_popen.return_value = mock.Mock(stdout=fake_output)
         smart_utils.read_smart_scsi(hwlst, 'fake')
 
@@ -91,7 +91,7 @@ class TestSmartUtils(unittest.TestCase):
     @mock.patch.object(subprocess, 'Popen')
     def test_read_smart_ata(self, mock_popen):
         hwlst = []
-        fake_output = sample('smartctl_ata').splitlines()
+        fake_output = sample('smartctl_ata', mode='rb').splitlines()
         mock_popen.return_value = mock.Mock(stdout=fake_output)
         smart_utils.read_smart_ata(hwlst, 'fake')
 
@@ -113,7 +113,7 @@ class TestSmartUtils(unittest.TestCase):
     def test_read_smart_call_smart_ata(self, mock_popen, mock_os_path_exists,
                                        mock_ata):
         hwlst = []
-        fake_output = sample('smartctl_ata').splitlines()
+        fake_output = sample('smartctl_ata', mode='rb').splitlines()
         mock_popen.return_value = mock.Mock(stdout=fake_output)
         smart_utils.read_smart(hwlst, 'fake')
 
@@ -125,7 +125,7 @@ class TestSmartUtils(unittest.TestCase):
     def test_read_smart_call_smart_scsi(self, mock_popen, mock_os_path_exists,
                                         mock_scsi):
         hwlst = []
-        fake_output = sample('smartctl_scsi').splitlines()
+        fake_output = sample('smartctl_scsi', mode='rb').splitlines()
         mock_popen.return_value = mock.Mock(stdout=fake_output)
         smart_utils.read_smart(hwlst, 'fake')
 
@@ -135,7 +135,7 @@ class TestSmartUtils(unittest.TestCase):
     @mock.patch.object(subprocess, 'Popen')
     def test_read_smart_nvme(self, mock_popen, mock_os_path_exists):
         hwlst = []
-        fake_output = sample('smartctl_nvme').splitlines()
+        fake_output = sample('smartctl_nvme', mode='rb').splitlines()
         mock_popen.return_value = mock.Mock(stdout=fake_output)
         smart_utils.read_smart_nvme(hwlst, 'fake_nvme')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=1.0 # Apache-2.0
-six # MIT
 ipaddress # PSF
 netaddr # BSD
 pexpect # ISC


### PR DESCRIPTION
Since we've dropped support for Python 2.7 and we're going for
Python 3.x only, we don't need the six library anymore.