### PR TITLE
detect: Fixing numa cpu_count computation

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -768,11 +768,8 @@ def get_cpus(hw_lst):
                     total_cpus = total_cpus + max_cpu - min_cpu + 1
                 else:
                     # or like 0,1
-                    if min_cpu is None:
-                        min_cpu = int(item)
-                    else:
-                        max_cpu = int(item)
-                        total_cpus = total_cpus + max_cpu - min_cpu + 1
+                    # As we don't have dashes, there is only one core to count
+                    total_cpus = total_cpus + 1
 
         # total_cpus = 12 for "0-5,48-53"
         hw_lst.append(('numa', ntag, 'cpu_count', total_cpus))

--- a/hardware/tests/results/detect_results.py
+++ b/hardware/tests/results/detect_results.py
@@ -100,6 +100,53 @@ GET_CPUS_RESULT = [('cpu', 'physical', 'number', 2),
                    ('numa', 'node_7', 'cpu_mask',
                     '0xfc0000000000fc0000000000')]
 
+GET_CPUS_7302_RESULT = [('cpu', 'physical', 'number', 1),
+                        ('cpu', 'physical_0', 'vendor', 'AuthenticAMD'),
+                        ('cpu', 'physical_0', 'product', 'AMD EPYC 7302P 16-Core Processor'),
+                        ('cpu', 'physical_0', 'cores', 16),
+                        ('cpu', 'physical_0', 'threads', 32),
+                        ('cpu', 'physical_0', 'family', 23),
+                        ('cpu', 'physical_0', 'model', 49),
+                        ('cpu', 'physical_0', 'stepping', 0),
+                        ('cpu', 'physical_0', 'l1d cache', '32K'),
+                        ('cpu', 'physical_0', 'l1i cache', '32K'),
+                        ('cpu', 'physical_0', 'l2 cache', '512K'),
+                        ('cpu', 'physical_0', 'l3 cache', '16384K'),
+                        ('cpu', 'physical_0', 'min_Mhz', 1500.0),
+                        ('cpu', 'physical_0', 'max_Mhz', 3000.0),
+                        ('cpu', 'physical_0', 'current_Mhz', 1794.163),
+                        ('cpu', 'physical_0', 'flags',
+                            'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 '
+                            'clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm '
+                            'constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni '
+                            'pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx '
+                            'f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse '
+                            '3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext '
+                            'perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate sme ssbd mba sev ibrs ibpb '
+                            'stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 cqm rdt_a rdseed adx smap '
+                            'clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc '
+                            'cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr wbnoinvd arat npt lbrv '
+                            'svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists '
+                            'pausefilter pfthreshold avic v_vmsave_vmload vgif umip rdpid overflow_recov '
+                            'succor smca'),
+                        ('cpu', 'logical', 'number', 32),
+                        ('numa', 'nodes', 'count', 8),
+                        ('numa', 'node_0', 'cpu_count', 4),
+                        ('numa', 'node_0', 'cpu_mask', '0xf0000000f'),
+                        ('numa', 'node_1', 'cpu_count', 4),
+                        ('numa', 'node_1', 'cpu_mask', '0xf0000000f0'),
+                        ('numa', 'node_2', 'cpu_count', 4),
+                        ('numa', 'node_2', 'cpu_mask', '0xf0000000f00'),
+                        ('numa', 'node_3', 'cpu_count', 4),
+                        ('numa', 'node_3', 'cpu_mask', '0xf0000000f000'),
+                        ('numa', 'node_4', 'cpu_count', 4),
+                        ('numa', 'node_4', 'cpu_mask', '0xf0000000f0000'),
+                        ('numa', 'node_5', 'cpu_count', 4),
+                        ('numa', 'node_5', 'cpu_mask', '0xf0000000f00000'),
+                        ('numa', 'node_6', 'cpu_count', 4),
+                        ('numa', 'node_6', 'cpu_mask', '0xf0000000f000000'),
+                        ('numa', 'node_7', 'cpu_count', 4),
+                        ('numa', 'node_7', 'cpu_mask', '0xf0000000f0000000')]
 
 GET_CPUS_VM_RESULT = [('cpu', 'physical', 'number', 1),
                       ('cpu', 'physical_0', 'vendor', 'GenuineIntel'),

--- a/hardware/tests/samples/lscpu-7302
+++ b/hardware/tests/samples/lscpu-7302
@@ -1,0 +1,32 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                32
+On-line CPU(s) list:   0-31
+Thread(s) per core:    2
+Core(s) per socket:    16
+Socket(s):             1
+NUMA node(s):          8
+Vendor ID:             AuthenticAMD
+CPU family:            23
+Model:                 49
+Model name:            AMD EPYC 7302P 16-Core Processor
+Stepping:              0
+CPU MHz:               1794.163
+CPU max MHz:           3000.0000
+CPU min MHz:           1500.0000
+BogoMIPS:              5989.13
+Virtualization:        AMD-V
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              512K
+L3 cache:              16384K
+NUMA node0 CPU(s):     0,1,16,17
+NUMA node1 CPU(s):     2,3,18,19
+NUMA node2 CPU(s):     4,5,20,21
+NUMA node3 CPU(s):     6,7,22,23
+NUMA node4 CPU(s):     8,9,24,25
+NUMA node5 CPU(s):     10,11,26,27
+NUMA node6 CPU(s):     12,13,28,29
+NUMA node7 CPU(s):     14,15,30,31
+Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate sme ssbd mba sev ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif umip rdpid overflow_recov succor smca

--- a/hardware/tests/samples/lscpu-7302x
+++ b/hardware/tests/samples/lscpu-7302x
@@ -1,0 +1,31 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                64
+On-line CPU(s) mask:   0xffffffffffffffff
+Thread(s) per core:    2
+Core(s) per socket:    32
+Socket(s):             1
+NUMA node(s):          8
+Vendor ID:             AuthenticAMD
+CPU family:            23
+Model:                 49
+Model name:            AMD EPYC 7502P 32-Core Processor
+Stepping:              0
+CPU MHz:               1506.661
+CPU max MHz:           2500.0000
+CPU min MHz:           1500.0000
+BogoMIPS:              4990.53
+Virtualization:        AMD-V
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              512K
+L3 cache:              16384K
+NUMA node0 CPU(s):     0xf0000000f
+NUMA node1 CPU(s):     0xf0000000f0
+NUMA node2 CPU(s):     0xf0000000f00
+NUMA node3 CPU(s):     0xf0000000f000
+NUMA node4 CPU(s):     0xf0000000f0000
+NUMA node5 CPU(s):     0xf0000000f00000
+NUMA node6 CPU(s):     0xf0000000f000000
+NUMA node7 CPU(s):     0xf0000000f0000000

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -72,6 +72,18 @@ class TestDetect(unittest.TestCase):
     @mock.patch('os.path.exists', return_value=False)
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
+                    sample('lscpu-7302').split('\n'),
+                    sample('lscpu-7302x').split('\n')])
+    def test_get_cpus_7302(self, mock_output_lines, mock_os_path_exists):
+        self.maxDiff=None
+        hw = []
+        detect.get_cpus(hw)
+        self.assertEqual(hw, detect_results.GET_CPUS_7302_RESULT)
+
+
+    @mock.patch('os.path.exists', return_value=False)
+    @mock.patch('hardware.detect_utils.output_lines',
+                side_effect=[
                     sample('lscpu-vm').split('\n'),
                     sample('lscpu-vmx').split('\n'),
                     ('powersave',),


### PR DESCRIPTION
The actual code was confused by a syntax like :  0,1,16,17
It was considering each value as a number of cores reporting 34 to this example.

This patch modify the logic and count only one core per comma when there isn't any dash ("-") in it.
This add a sample of an AMD 7302 so have this configuration.

Signed-off-by: Erwan Velu <e.velu@criteo.com>