### PR TITLE
Get the CPU scaling governor on kernels < 4.3

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -19,6 +19,7 @@
 
 
 import argparse
+import contextlib
 import fcntl
 import ipaddress
 import json
@@ -672,6 +673,22 @@ def get_cpus(hw_lst):
             pass
         return v
 
+    def _get_governor(lcpu):
+        """Return the scaling governor of a logical core.
+
+        :param lcpu: the logical core number
+        :returns: the scaling governor if it exists, otherwise None
+        """
+        with contextlib.suppress(IOError):
+            return _from_file("/sys/devices/system/cpu/cpufreq/"
+                              "policy{}/scaling_governor".format(lcpu))
+
+        # fallback to the old interface available in kernels < 4.3;
+        with contextlib.suppress(IOError):
+            return _from_file("/sys/devices/system/cpu/cpu{}/cpufreq/"
+                              "scaling_governor".format(lcpu))
+        return None
+
     # Extracting lspcu information
     lscpu = {}
     output = detect_utils.output_lines('LANG=en_US.UTF-8 lscpu')
@@ -732,13 +749,10 @@ def get_cpus(hw_lst):
     # Governors could be different on logical cpus
     for cpu in range(int(lscpu['CPU(s)'])):
         ltag = "logical_{}".format(cpu)
-        try:
-            value = _from_file(("/sys/devices/system/cpu/cpufreq/"
-                                "policy{}/scaling_governor".format(cpu)))
-        except IOError:
-            pass
-        else:
-            hw_lst.append(('cpu', ltag, "governor", value))
+
+        governor = _get_governor(cpu)
+        if governor is not None:
+            hw_lst.append(('cpu', ltag, "governor", governor))
 
     # Extracting numa nodes
     try:

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -62,9 +62,10 @@ class TestDetect(unittest.TestCase):
             calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
         # Once per processor
         for i in range(1):
-            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
-                 i)
-            calls.append(mock.call(f))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpufreq/'
+                                    'policy{}/scaling_governor'.format(i))))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpu{}/cpufreq/'
+                                    'scaling_governor'.format(i))))
         # NOTE(tonyb): We can't use assert_has_calls() because it's too
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
@@ -97,9 +98,10 @@ class TestDetect(unittest.TestCase):
             calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
         # Once per processor
         for i in range(2):
-            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
-                 i)
-            calls.append(mock.call(f))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpufreq/'
+                                    'policy{}/scaling_governor'.format(i))))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpu{}/cpufreq/'
+                                    'scaling_governor'.format(i))))
         # NOTE(tonyb): We can't use assert_has_calls() because it's too
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
@@ -122,9 +124,10 @@ class TestDetect(unittest.TestCase):
             calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
         # Once per processor
         for i in range(8):
-            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
-                 i)
-            calls.append(mock.call(f))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpufreq/'
+                                    'policy{}/scaling_governor'.format(i))))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpu{}/cpufreq/'
+                                    'scaling_governor'.format(i))))
         # NOTE(tonyb): We can't use assert_has_calls() because it's too
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
@@ -144,9 +147,10 @@ class TestDetect(unittest.TestCase):
             calls.append(mock.call('/sys/devices/system/cpu/cpufreq/boost'))
         # Once per processor
         for i in range(144):
-            f = ('/sys/devices/system/cpu/cpufreq/policy%d/scaling_governor' %
-                 i)
-            calls.append(mock.call(f))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpufreq/'
+                                    'policy{}/scaling_governor'.format(i))))
+            calls.append(mock.call(('/sys/devices/system/cpu/cpu{}/cpufreq/'
+                                    'scaling_governor'.format(i))))
         # NOTE(tonyb): We can't use assert_has_calls() because it's too
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)


### PR DESCRIPTION
Prior to kernel version 4.3,
/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor was used
instead of /sys/devices/system/cpu/cpufreq/policy{}/scaling_governor.

Try to access the first file in case the second one does not exist.