### PR TITLE
Move detect_areca in the areca module

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -122,51 +122,6 @@ def detect_hpa(hw_lst):
     return True
 
 
-def detect_areca(hw_lst):
-    'Detect Areca controller configuration'
-    device = areca.sys_info()
-    if not device:
-        sys.stderr.write('Info: detect_areca: No controller found\n')
-        return
-    if "ControllerName" not in device.keys():
-        sys.stderr.write('Info: detect_areca: Cannot found controller name\n')
-        return
-
-    sys.stderr.write('Info: detect_areca: Found %s version %s\n' %
-                     (device['ControllerName'], device['FirmwareVersion']))
-
-    areca.disable_password()
-
-    for info in device.keys():
-        hw_lst.append(('areca', 'system', info, device[info]))
-
-    adsys = areca.adsys_info()
-    for info in adsys.keys():
-        hw_lst.append(('areca', 'system', info, adsys[info]))
-
-    cfg = areca.sys_showcfg()
-    for info in cfg.keys():
-        hw_lst.append(('areca', 'config', info, cfg[info]))
-
-    hw_info = areca.hw_info()
-    for info in hw_info.keys():
-        hw_lst.append(('areca', 'hardware', info, hw_info[info]))
-
-    pwr_info = areca.hdd_pwr_info()
-    for info in pwr_info.keys():
-        hw_lst.append(('areca', 'power', info, pwr_info[info]))
-
-    for disk_number in range(1, 255):
-        disk_info = areca.disk_info(disk_number)
-        # If we don't have info about that disk, let's stop here
-        if len(disk_info) < 2:
-            break
-        # Extracting disk information
-        for info in disk_info:
-            hw_lst.append(('areca', "disk%d" % disk_number, info,
-                           disk_info[info]))
-
-
 def detect_megacli(hw_lst):
     'Detect LSI MegaRAID controller configuration.'
     ctrl_num = megacli.adp_count()
@@ -987,7 +942,8 @@ def main():
     args = parse_args(sys.argv[1:])
 
     hrdw = []
-    detect_areca(hrdw)
+    areca_hrdw = areca.detect()
+    hrdw.append(areca_hrdw)
     detect_hpa(hrdw)
     detect_megacli(hrdw)
     detect_disks(hrdw)

--- a/hardware/tests/test_areca.py
+++ b/hardware/tests/test_areca.py
@@ -25,15 +25,15 @@ class TestMegacliTest(unittest.TestCase):
     def setUp(self):
         def my_run(*args, **arr):
             return self.output
-        self.run = areca.run_areca
-        areca.run_areca = my_run
+        self.run = areca._run_areca
+        areca._run_areca = my_run
 
     def tearDown(self):
         areca.run = self.run
 
     def test_sys_info(self):
         self.output = sample('areca_sysinfo')
-        self.assertEqual(areca.sys_info(),
+        self.assertEqual(areca._sys_info(),
                          {'MainProcessor': 800,
                           'MainProcessor/unit': 'MHz',
                           'CpuIcacheSize': 32,
@@ -51,7 +51,7 @@ class TestMegacliTest(unittest.TestCase):
 
     def test_sys_showcfg(self):
         self.output = sample('areca_sys_showcfg')
-        self.assertEqual(areca.sys_showcfg(),
+        self.assertEqual(areca._sys_showcfg(),
                          {'SystemBeeperSetting': 'Enabled',
                           'BackgroundTaskPriority': 'High(80%)',
                           'Jbod/RaidConfiguration': 'JBOD',
@@ -74,7 +74,7 @@ class TestMegacliTest(unittest.TestCase):
 
     def test_adsys_info(self):
         self.output = sample('areca_adsysinfo')
-        self.assertEqual(areca.adsys_info(),
+        self.assertEqual(areca._adsys_info(),
                          {'TlerSetting': 7,
                           'TlerSetting/unit': 'Seconds',
                           'TimeoutSetting': 8,
@@ -98,7 +98,7 @@ class TestMegacliTest(unittest.TestCase):
 
     def test_hw_info(self):
         self.output = sample('areca_hw_info')
-        self.assertEqual(areca.hw_info(),
+        self.assertEqual(areca._hw_info(),
                          {'Enclosure1/12V': '12.220',
                           'Enclosure1/12V/unit': 'V',
                           'Enclosure1/3.3V': '3.328',
@@ -126,7 +126,7 @@ class TestMegacliTest(unittest.TestCase):
 
     def test_hddpwr_info(self):
         self.output = sample('areca_hddpwr_info')
-        self.assertEqual(areca.hdd_pwr_info(),
+        self.assertEqual(areca._hdd_pwr_info(),
                          {'StaggerPowerOnControl': '0.7',
                           'TimeToHddLowPowerIdle': 'Disabled',
                           'TimeToHddLowRpmMode': 'Disabled',
@@ -134,7 +134,7 @@ class TestMegacliTest(unittest.TestCase):
 
     def test_diskinfo(self):
         self.output = sample('areca_disks_info')
-        self.assertEqual(areca.disk_info(1),
+        self.assertEqual(areca._disk_info(1),
                          {'DeviceLocation': 'Enclosure#1 Slot#8',
                           'DeviceState': 'NORMAL',
                           'DeviceTemperature': 27,
@@ -153,9 +153,3 @@ class TestMegacliTest(unittest.TestCase):
                           'SmartSpinupRetries': '100(60)',
                           'SmartSpinupTime': '122(24)',
                           'TimeoutCount': 0})
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-# test_areca.py ends here


### PR DESCRIPTION
Start moving stuff out of detect.
That will also allow us to stop passing the same huge list of data
between functions and modules.
In the long term it will help testing and converting to a more sane
schema.