### PR TITLE
Bump hacking to 3.0.0

### DIFF
--- a/hardware/areca.py
+++ b/hardware/areca.py
@@ -48,7 +48,7 @@ def parse_output(output, rev=False):
         if len(lis) == 2:
             if "GuiErrMsg" in lis[0]:
                 continue
-            match = re.search('\[(Enclosure#.*)', lis[0])
+            match = re.search(r"\[(Enclosure#.*)", lis[0])
             if match:
                 append = match.group(1).replace('#', '') + "/"
                 continue

--- a/hardware/benchmark/disk.py
+++ b/hardware/benchmark/disk.py
@@ -95,7 +95,7 @@ def run_fio(hw_lst, disks_list, mode, io_size, time, rampup_time):
         if ('MYJOB-' in line) and ('pid=' in line):
             # MYJOB-sda: (groupid=0, jobs=1): err= 0: pid=23652: Mon Sep  9
             # 16:21:42 2013
-            current_disk = re.search('MYJOB-(.*): \(groupid', line).group(1)
+            current_disk = re.search(r"MYJOB-(.*): \(groupid", line).group(1)
             continue
         if ("read : io=" in line) or ("write: io=" in line):
             # read : io=169756KB, bw=16947KB/s, iops=4230, runt= 10017msec

--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -321,8 +321,9 @@ def detect_ipmi(hw_lst):
     modprobe("ipmi_smb")
     modprobe("ipmi_si")
     modprobe("ipmi_devintf")
-    if (os.path.exists('/dev/ipmi0') or os.path.exists('/dev/ipmi/0') or
-            os.path.exists('/dev/ipmidev/0')):
+    if (os.path.exists('/dev/ipmi0')
+            or os.path.exists('/dev/ipmi/0')
+            or os.path.exists('/dev/ipmidev/0')):
         for channel in range(0, 16):
             status, _ = cmd('ipmitool channel info %d 2>&1 | grep -sq Volatile'
                             % channel)
@@ -527,10 +528,8 @@ def detect_system(hw_lst, output=None):
                         bank_count = bank_count + 1
                         for bank in elt.findall(".//node[@id='%s']" %
                                                 (bank_list.get('id'))):
-                            bank_id = bank_list.get('id').replace("bank:",
-                                                                  "bank" +
-                                                                  location +
-                                                                  ":")
+                            bank_id = bank_list.get('id').replace(
+                                "bank:", "bank" + location + ":")
                             find_element(bank, 'size', 'size',
                                          bank_id, 'memory')
                             find_element(bank, 'clock', 'clock',
@@ -748,8 +747,8 @@ def get_cpus(hw_lst):
                 if conv:
                     value = conv(value)
             elif t_key == 'threads':
-                value = (int(lscpu.get('Thread(s) per core', 1)) *
-                         int(lscpu.get('Core(s) per socket', 1)))
+                value = (int(lscpu.get('Thread(s) per core', 1))
+                         * int(lscpu.get('Core(s) per socket', 1)))
             if value is not None:
                 hw_lst.append(('cpu', ptag, t_key, value))
 
@@ -771,7 +770,7 @@ def get_cpus(hw_lst):
     # Allow for sparse numa nodes.
     numa_nodes = []
     for key in lscpux:
-        match = re.match('NUMA node(\d+) CPU\(s\)', key)
+        match = re.match(r"NUMA node(\d+) CPU\(s\)", key)
         if match:
             numa_nodes.append((key, int(match.groups()[0])))
     # NOTE(tonyb): Explicitly sort the list as prior to python 3.7? keys() did

--- a/hardware/generate.py
+++ b/hardware/generate.py
@@ -78,8 +78,9 @@ def _generate_values(pattern, prefix=_PREFIX):
             yield pattern
     elif isinstance(pattern, str):
         parts = pattern.split('.')
-        if (_IPV4_RANGE_REGEXP.search(pattern) and len(parts) == 4 and
-                (pattern.find(':') != -1 or pattern.find('-') != -1)):
+        if (_IPV4_RANGE_REGEXP.search(pattern)
+                and len(parts) == 4
+                and (pattern.find(':') != -1 or pattern.find('-') != -1)):
             gens = [_generate_range(part) for part in parts]
             for part0 in gens[0]:
                 for part1 in gens[1]:

--- a/hardware/hpacucli.py
+++ b/hardware/hpacucli.py
@@ -171,7 +171,7 @@ def parse_ctrl_ld_show(output):
         # handle this kind of lines:
         # Disk Name: /dev/sda          Mount Points: None
         elif len(res) == 3:
-            middle = re.split('\s+', res[1].strip(), 1)
+            middle = re.split(r"\s+", res[1].strip(), 1)
             arr[res[0].strip()] = middle[0]
             arr[middle[1]] = res[2].strip()
     return arr

--- a/hardware/matcher.py
+++ b/hardware/matcher.py
@@ -265,13 +265,12 @@ As a result, we do have a filename like :
 
     # Duplicate items as it will be modified by match_* functions
     hw_items = list(items)
-    sysvars = {}
-    sysvars['sysname'] = ''
+    sysvars = {'sysname': ''}
 
     if match_spec(('system', 'product', 'vendor', '$sysprodvendor'),
                   hw_items, sysvars):
-        sysvars['sysname'] += (re.sub(r'\W+', '', sysvars['sysprodvendor']) +
-                               '-')
+        sysvars['sysname'] += (re.sub(r'\W+', '',
+                                      sysvars['sysprodvendor']) + '-')
 
     if match_spec(('system', 'product', 'name', '$sysprodname'),
                   hw_items, sysvars):

--- a/hardware/megacli.py
+++ b/hardware/megacli.py
@@ -176,7 +176,7 @@ def enc_info(ctrl):
     all_ = list(map(parse_output, parts))
     for entry in all_:
         for key in entry.keys():
-            if re.search('Enclosure\d+', key):
+            if re.search(r"Enclosure\d+", key):
                 entry['Enclosure'] = int(key[len('Enclosure'):])
                 del entry[key]
                 break

--- a/hardware/state.py
+++ b/hardware/state.py
@@ -190,8 +190,9 @@ Need to call unlock to release the lock.
     @staticmethod
     def _get_value(lines, spec, key):
         info = {}
-        if (matcher.match_spec(spec, lines, info) and key in info and
-                info[key][0] != '$'):
+        if (matcher.match_spec(spec, lines, info)
+                and key in info
+                and info[key][0] != '$'):
             return int(info[key])
         return None
 

--- a/hardware/tests/test_hpacucli.py
+++ b/hardware/tests/test_hpacucli.py
@@ -152,15 +152,15 @@ class TestController(unittest.TestCase):
                                 )
 
     def test_ctrl_pd_all_show(self):
-        self.cli.process.before = ('ctrl slot=2 pd all show' +
-                                   CTRL_PD_ALL_SHOW_OUTPUT)
+        self.cli.process.before = ('ctrl slot=2 pd all show'
+                                   + CTRL_PD_ALL_SHOW_OUTPUT)
         return self.assertEqual(self.cli.ctrl_pd_all_show('slot=2'),
                                 CTRL_PD_ALL_SHOW_RESULT
                                 )
 
     def test_ctrl_ld_all_show(self):
-        self.cli.process.before = ('ctrl slot=2 ld all show' +
-                                   CTRL_LD_ALL_SHOW_OUTPUT)
+        self.cli.process.before = ('ctrl slot=2 ld all show'
+                                   + CTRL_LD_ALL_SHOW_OUTPUT)
         return self.assertEqual(self.cli.ctrl_ld_all_show('slot=2'),
                                 CTRL_LD_ALL_SHOW_RESULT
                                 )
@@ -174,9 +174,9 @@ class TestController(unittest.TestCase):
 
     @unittest.skip("WIP")
     def test_ctrl_create_ld(self):
-        self.cli.process.before = ('ctrl slot=2 ld 2 show' +
-                                   CTRL_LD_ALL_SHOW_OUTPUT +
-                                   CTRL_LD_SHOW_OUTPUT)
+        self.cli.process.before = ('ctrl slot=2 ld 2 show'
+                                   + CTRL_LD_ALL_SHOW_OUTPUT
+                                   + CTRL_LD_SHOW_OUTPUT)
         return self.assertEqual(
             self.cli.ctrl_create_ld('slot=2', ('2I:1:7', '2I:1:8'), '1'),
             '/dev/sda'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=1.0.0,<1.1.0 # Apache-2.0
+hacking>=3.0.0,<3.1.0 # Apache-2.0
 
 # We install pyflakes after hacking as it's bugged in the version hacking
 # requires. Also using a more modern version.

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands = sphinx-build -b html -W doc/source doc/build/html
 # for the time being.
 # E123, E125 skipped as they are invalid PEP-8.
 show-source = True
-ignore = E123,E125,H803,H302,H105,H238
+ignore = E123,E125,H803,H302,H105,H238,W503
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build
 


### PR DESCRIPTION
The new version enables a lot of standard flake8 checks, so a few
fixes are required. W503 is disabled as it conflicts with W504
and the latter seems to be preferred nowadays.