### PR TITLE
Set flake8-import-order min version to 0.17.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,6 @@ coverage>=3.6 # Apache-2.0
 discover # BSD
 python-subunit # Apache-2.0/BSD
 stestr>=2.0.0 # Apache-2.0
-flake8-import-order>=0.13
+flake8-import-order>=0.17.1 # LGPLv3
 testtools>=0.9.34 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD


### PR DESCRIPTION
Full py3 compatible version.
Add all Python3 modules to stdlib list.