### PR TITLE
setup: Defaulting to python3

### DIFF
--- a/hardware/areca.py
+++ b/hardware/areca.py
@@ -190,4 +190,9 @@ def detect():
             hwlist.append(('areca', "disk%d" % disk_number, info,
                            disk_info_out[info]))
 
-    return hwlist
+    if len(hwlist):
+        return hwlist
+
+    # If we dont't detect any areca controller, return None
+    # This avoid having empty lists
+    return None

--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -927,8 +927,7 @@ def main():
     args = parse_args(sys.argv[1:])
 
     hrdw = []
-    areca_hrdw = areca.detect()
-    hrdw.append(areca_hrdw)
+    hrdw.append(areca.detect())
     detect_hpa(hrdw)
     detect_megacli(hrdw)
     detect_disks(hrdw)
@@ -954,6 +953,8 @@ def main():
                               destructive=args.benchmark_disk_destructive)
 
     hrdw = clean_tuples(hrdw)
+
+    hrdw = list(filter(None, hrdw))
 
     if args.human:
         pprint.pprint(hrdw)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2013 Hewlett-Packard Development Company, L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
On systems where both python2 & 3 are installed, its better enforcing python3.

If python points to python2, hardware-detect fails with the following message :
	-bash-4.2# hardware-detect
	Traceback (most recent call last):
	  File "/usr/bin/hardware-detect", line 6, in <module>
	    from hardware.detect import main
	  File "/usr/lib/python2.7/site-packages/hardware/detect.py", line 34, in <module>
	    from hardware import areca
	  File "/usr/lib/python2.7/site-packages/hardware/areca.py", line 99
	    def _run_and_parse(*args, rev=False):

Let's default to python3.

Signed-off-by: Erwan Velu <e.velu@criteo.com>