### PR TITLE
Move logic to retrieve system uuid to detect_utils

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -28,7 +28,6 @@ import struct
 from subprocess import PIPE
 from subprocess import Popen
 import sys
-import uuid
 import xml.etree.ElementTree as ET
 
 from hardware import areca
@@ -150,45 +149,6 @@ def detect_infiniband(hw_lst):
     return True
 
 
-def _get_uuid_x86_64():
-    'Get uuid from dmidecode'
-    uuid_cmd = Popen("dmidecode -t 1 | grep UUID | "
-                     "awk '{print $2}'",
-                     shell=True,
-                     stdout=PIPE,
-                     universal_newlines=True)
-    stdout = uuid_cmd.communicate()[0]
-    return stdout.rstrip()
-
-
-def _get_uuid_ppc64le(hw_lst):
-    vendor = None
-    serial = None
-    for (_, _, sys_subtype, value) in hw_lst:
-        if sys_subtype == 'vendor':
-            vendor = value
-        if sys_subtype == 'serial':
-            serial = value
-
-    system_uuid = None
-    system_uuid_fname = '/sys/firmware/devicetree/base/system-uuid'
-    if os.access(system_uuid_fname, os.R_OK):
-        with open(system_uuid_fname) as uuidfile:
-            system_uuid = uuidfile.read().rstrip(' \t\r\n\0')
-    elif vendor and serial:
-        root = uuid.UUID(bytes=b'\x00' * 16)
-        vendor_uuid = uuid.uuid5(root, vendor)
-        system_uuid = str(uuid.uuid5(vendor_uuid, serial))
-
-    return system_uuid
-
-
-def get_uuid(hw_lst):
-    if os.uname()[4] == 'ppc64le':
-        return _get_uuid_ppc64le(hw_lst)
-    return _get_uuid_x86_64()
-
-
 def _get_value(hw_lst, *vect):
     for i in hw_lst:
         if i[0:3] == vect:
@@ -228,7 +188,7 @@ def detect_system(hw_lst, output=None):
         find_element(xml, "./node/product", 'name')
         find_element(xml, "./node/vendor", 'vendor')
         find_element(xml, "./node/version", 'version')
-        uuid = get_uuid(hw_lst)
+        uuid = detect_utils.get_uuid(hw_lst)
 
         if uuid:
             # If we have an uuid, we shall check if it's part of a

--- a/hardware/tests/test_detect_utils.py
+++ b/hardware/tests/test_detect_utils.py
@@ -10,7 +10,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import subprocess
 import unittest
+from unittest import mock
 
 from hardware import detect_utils
 from hardware.tests.results import detect_utils_results
@@ -44,3 +46,51 @@ class TestDetectUtils(unittest.TestCase):
             detect_utils.clean_tuples([(b'\x8f' * 4, b'\x8f' * 4,
                                         b'h\xc3\xa9llo', 1)]),
             [(u'\ufffd' * 4, u'\ufffd' * 4, u'h\xe9llo', 1)])
+
+    @mock.patch.object(subprocess, 'Popen')
+    @mock.patch('os.uname', return_value=('', '', '', '', 'x86_64'))
+    def test_get_uuid_x86_64(self, mock_uname, mock_popen):
+        # This is more complex and 'magic' than I'd like :/
+        process_mock = mock.Mock()
+        attrs = {'communicate.return_value': ('83462C81-52BA-11CB-870F', '')}
+        process_mock.configure_mock(**attrs)
+        mock_popen.return_value = process_mock
+
+        hw_list = []
+        system_uuid = detect_utils.get_uuid(hw_list)
+        mock_popen.assert_has_calls([
+            mock.call("dmidecode -t 1 | grep UUID | " "awk '{print $2}'",
+                      shell=True, stdout=subprocess.PIPE,
+                      universal_newlines=True)])
+        self.assertEqual('83462C81-52BA-11CB-870F', system_uuid)
+
+    @mock.patch('os.uname', return_value=('', '', '', '', 'ppc64le'))
+    @mock.patch('os.access', return_value=True)
+    def test_get_uuid_ppc64le_ok_generate(self, mock_access, mock_uname):
+        expected_uuid = 'a2724b67-c27e-5e5f-aa2b-3089a2bd8f41'
+        fileobj = mock.mock_open(read_data=expected_uuid)
+        with mock.patch('builtins.open', fileobj, create=True):
+            uuid = detect_utils.get_uuid([])
+        self.assertEqual(expected_uuid, uuid)
+
+    @mock.patch('os.uname', return_value=('', '', '', '', 'ppc64le'))
+    def test_get_uuid_ppc64le_ok_read(self, mock_uname):
+        hw_list = [('sys_cls', 'sys_type', 'vendor', 'IBM'),
+                   ('sys_cls', 'sys_type', 'serial', '1234567A')]
+        self.assertEqual('a2724b67-c27e-5e5f-aa2b-3089a2bd8f41',
+                         detect_utils.get_uuid(hw_list))
+
+    @mock.patch('os.uname', return_value=('', '', '', '', 'ppc64le'))
+    def test_get_uuid_ppc64le_missing_serial(self, mock_uname):
+        hw_list = [('sys_cls', 'sys_type', 'vendor', 'IBM')]
+        self.assertIsNone(detect_utils.get_uuid(hw_list))
+
+    @mock.patch('os.uname', return_value=('', '', '', '', 'ppc64le'))
+    def test_get_uuid_ppc64le_missing_vendor(self, mock_uname):
+        hw_list = [('sys_cls', 'sys_type', 'serial', '1234567A')]
+        self.assertIsNone(detect_utils.get_uuid(hw_list))
+
+    @mock.patch('os.uname', return_value=('', '', '', '', 'ppc64le'))
+    def test_get_uuid_ppc64le_no_hw_list(self, mock_uname):
+        hw_list = []
+        self.assertIsNone(detect_utils.get_uuid(hw_list))


### PR DESCRIPTION
Being a generic helper function, get_uuid should be moved to
detect_utils.
This is also needed for the future refactor of detect_system.