### PR TITLE
Set safe version of hacking

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=3.0.0,<3.1.0 # Apache-2.0
+hacking>=3.1.0,<4.0.0 # Apache-2.0
 
 coverage>=3.6 # Apache-2.0
 discover # BSD
@@ -11,3 +11,5 @@ stestr>=2.0.0 # Apache-2.0
 flake8-import-order>=0.17.1 # LGPLv3
 testtools>=0.9.34 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD
+pycodestyle>=2.0.0,<2.7.0 # MIT
+


### PR DESCRIPTION
Versions of hacking from 3.1.0 until 4.0.0 NOT included are supposed
to require a safe version of flake8, so besides normale issues related
to minor version upgrades, we can safely use those versions.
Also forcing pycodestyle versions to be compatible with flake8 installed
by hacking.