### PR TITLE
Move more generic functions to detect-utils

### DIFF
--- a/hardware/detect_utils.py
+++ b/hardware/detect_utils.py
@@ -271,3 +271,31 @@ def get_uuid(hw_lst):
     if os.uname()[4] == 'ppc64le':
         return _get_uuid_ppc64le(hw_lst)
     return _get_uuid_x86_64()
+
+
+def get_value(hw_lst, *vect):
+    for i in hw_lst:
+        if i[0:3] == vect:
+            return i[3]
+    return ''
+
+
+def get_cidr(netmask):
+    """Convert a netmask to a CIDR."""
+    binary_str = ''
+    for octet in netmask.split('.'):
+        binary_str += bin(int(octet))[2:].zfill(8)
+    return str(len(binary_str.rstrip('0')))
+
+
+def from_file(filename):
+    """Open a file and read its first line.
+
+    :param filename: the name of the file to be read
+    :returns: string -- the first line of filename, stripped of the final '\n'
+    :raises: IOError
+    """
+
+    with open(filename) as f:
+        value = f.readline().rstrip('\n')
+    return value

--- a/hardware/tests/test_detect.py
+++ b/hardware/tests/test_detect.py
@@ -16,6 +16,7 @@ import unittest
 from unittest import mock
 
 from hardware import detect
+from hardware import detect_utils
 from hardware.tests.results import detect_results
 from hardware.tests.utils import sample
 
@@ -28,10 +29,7 @@ from hardware.tests.utils import sample
             lambda *args, **kwargs: [])
 class TestDetect(unittest.TestCase):
 
-    def test_get_cidr(self):
-        self.assertEqual(detect.get_cidr('255.255.0.0'), '16')
-
-    @mock.patch('hardware.detect._from_file', side_effect=IOError())
+    @mock.patch('hardware.detect_utils.from_file', side_effect=IOError())
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
                     sample('lscpu').split('\n'),
@@ -55,7 +53,7 @@ class TestDetect(unittest.TestCase):
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
 
-    @mock.patch('hardware.detect._from_file', side_effect=IOError())
+    @mock.patch('hardware.detect_utils.from_file', side_effect=IOError())
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
                     sample('lscpu-7302').split('\n'),
@@ -66,7 +64,7 @@ class TestDetect(unittest.TestCase):
         detect.get_cpus(hw)
         self.assertEqual(hw, detect_results.GET_CPUS_7302_RESULT)
 
-    @mock.patch('hardware.detect._from_file', side_effect=IOError())
+    @mock.patch('hardware.detect_utils.from_file', side_effect=IOError())
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
                     sample('lscpu-vm').split('\n'),
@@ -92,7 +90,7 @@ class TestDetect(unittest.TestCase):
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
 
-    @mock.patch('hardware.detect._from_file', side_effect=IOError())
+    @mock.patch('hardware.detect_utils.from_file', side_effect=IOError())
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
                     sample('lscpu_aarch64').split('\n'),
@@ -119,7 +117,7 @@ class TestDetect(unittest.TestCase):
         # permissive.  We want an exact match
         self.assertEqual(calls, mock_throws_ioerror.mock_calls)
 
-    @mock.patch('hardware.detect._from_file', side_effect=IOError())
+    @mock.patch('hardware.detect_utils.from_file', side_effect=IOError())
     @mock.patch('hardware.detect_utils.output_lines',
                 side_effect=[
                     sample('lscpu_ppc64le').split('\n'),
@@ -205,21 +203,17 @@ class TestDetect(unittest.TestCase):
         detect.detect_system(result, sample('lshw'))
         self.assertEqual(result, detect_results.DETECT_SYSTEM_RESULT)
 
-    def test_get_value(self):
-        self.assertEqual(detect._get_value([('a', 'b', 'c', 'd')],
-                                           'a', 'b', 'c'), 'd')
-
     def test_fix_bad_serial_zero(self):
         hwl = [('system', 'product', 'serial', '0000000000')]
         detect.fix_bad_serial(hwl, 'uuid', '', '')
-        self.assertEqual(detect._get_value(hwl, 'system', 'product', 'serial'),
-                         'uuid')
+        self.assertEqual(detect_utils.get_value(
+            hwl, 'system', 'product', 'serial'), 'uuid')
 
     def test_fix_bad_serial_mobo(self):
         hwl = [('system', 'product', 'serial', '0123456789')]
         detect.fix_bad_serial(hwl, '', 'mobo', '')
-        self.assertEqual(detect._get_value(hwl, 'system', 'product', 'serial'),
-                         'mobo')
+        self.assertEqual(detect_utils.get_value(
+            hwl, 'system', 'product', 'serial'), 'mobo')
 
     @mock.patch.object(detect, 'Popen')
     @mock.patch('os.environ.copy')

--- a/hardware/tests/test_detect_utils.py
+++ b/hardware/tests/test_detect_utils.py
@@ -94,3 +94,10 @@ class TestDetectUtils(unittest.TestCase):
     def test_get_uuid_ppc64le_no_hw_list(self, mock_uname):
         hw_list = []
         self.assertIsNone(detect_utils.get_uuid(hw_list))
+
+    def test_get_value(self):
+        self.assertEqual(detect_utils.get_value([('a', 'b', 'c', 'd')],
+                                                'a', 'b', 'c'), 'd')
+
+    def test_get_cidr(self):
+        self.assertEqual(detect_utils.get_cidr('255.255.0.0'), '16')


### PR DESCRIPTION
Move functions that can be used by more classes and functions
to the detect-utils module as utils functions.