### PR TITLE
Fix final output

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -271,15 +271,15 @@ def main():
 
     hrdw = []
 
-    hrdw.append(areca.detect())
-    hrdw.append(hpacucli.detect())
-    hrdw.append(megacli.detect())
-    hrdw.append(diskinfo.detect())
+    hrdw.extend(areca.detect())
+    hrdw.extend(hpacucli.detect())
+    hrdw.extend(megacli.detect())
+    hrdw.extend(diskinfo.detect())
 
     system_info = system.detect()
     if not system_info:
         sys.exit(1)
-    hrdw.append(system_info)
+    hrdw.extend(system_info)
 
     detect_ipmi(hrdw)
     detect_infiniband(hrdw)


### PR DESCRIPTION
Since the new detect functions in the separate modules return
lists, we should not append them to the final list but instead
extend it.
This fixes the issue described in [1] where the extra_hardware
plugin in ironic-inspector tries to convert the data collected
by the ipa ramdisk but gets an unexpected list inside a list.

[1] https://bugs.launchpad.net/tripleo/+bug/1901917