### PR TITLE
Update requirements and tox minversion

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,14 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=3.1.0,<4.0.0 # Apache-2.0
-
-coverage>=3.6 # Apache-2.0
-discover # BSD
-python-subunit # Apache-2.0/BSD
 stestr>=2.0.0 # Apache-2.0
-flake8-import-order>=0.17.1 # LGPLv3
 testtools>=0.9.34 # MIT
 Babel!=2.4.0,>=2.3.4 # BSD
-pycodestyle>=2.0.0,<2.7.0 # MIT
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.1.0
+minversion = 3.9.0
 envlist = py36,py37,py38,pep8,cover,docs
 skipsdist = True
 ignore_basepython_conflict=true
@@ -21,6 +21,10 @@ commands =
     stestr run {posargs}
 
 [testenv:pep8]
+deps=
+    hacking>=3.1.0,<4.0.0 # Apache-2.0
+    flake8-import-order>=0.17.1 # LGPLv3
+    pycodestyle>=2.0.0,<2.7.0 # MIT
 commands = flake8 {posargs}
 
 [testenv:venv]
@@ -30,6 +34,9 @@ deps =
 commands = {posargs}
 
 [testenv:cover]
+deps=
+    {[testenv]deps}
+    coverage>=3.6 # Apache-2.0
 setenv =
     VIRTUAL_ENV={envdir}
     PYTHON=coverage run --source hardware --omit='*tests*' --parallel-mode


### PR DESCRIPTION
Move test requirements for pep8 and coverage to tox.ini
Increase minversion of tox to support inline comments [1]

Also remove unneeded test requirements.

[1] https://tox.readthedocs.io/en/latest/changelog.html#v3-9-0-2019-04-17