### PR TITLE
Remove ddr timings info

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -142,7 +142,6 @@ def main():
     hrdw.extend(ib.detect())
     hrdw.extend(sensors.detect_temperatures())
 
-    detect_utils.get_ddr_timing(hrdw)
     detect_utils.ipmi_sdr(hrdw)
     detect_rtc_clock(hrdw)
     detect_auxv(hrdw)

--- a/hardware/detect_utils.py
+++ b/hardware/detect_utils.py
@@ -14,7 +14,6 @@
 
 import contextlib
 import os
-import platform
 import re
 import subprocess
 import sys
@@ -130,54 +129,6 @@ def which(program):
                 return exe_file
 
     return None
-
-
-def get_ddr_timing(hw_):
-    """Report the DDR timings"""
-    sys.stderr.write('Reporting DDR Timings\n')
-    found = False
-    ddrprocess = subprocess.Popen('ddr-timings-%s' % platform.machine(),
-                                  shell=True, stdout=subprocess.PIPE)
-# DDR   tCL   tRCD  tRP   tRAS  tRRD  tRFC  tWR   tWTPr tRTPr tFAW  B2B
-# 0 |  11    15    15    31     7   511    11    31    15    63    31
-
-    for line in ddrprocess.stdout:
-        if 'is a Triple' in line:
-            hw_.append(('memory', 'DDR', 'type', '3'))
-            continue
-
-        if 'is a Dual' in line:
-            hw_.append(('memory', 'DDR', 'type', '2'))
-            continue
-
-        if 'is a Single' in line:
-            hw_.append(('memory', 'DDR', 'type', '1'))
-            continue
-
-        if 'is a Zero' in line:
-            hw_.append(('memory', 'DDR', 'type', '0'))
-            continue
-
-        if "DDR" in line:
-            found = True
-            continue
-
-        if found is True:
-            (ddr_channel, tCL, tRCD, tRP, tRAS,
-             tRRD, tRFC, tWR, tWTPr,
-             tRTPr, tFAW, B2B) = line.rstrip('\n').replace('|', ' ').split()
-            ddr_channel = ddr_channel.replace('#', '')
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tCL', tCL))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRCD', tRCD))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRP', tRP))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRAS', tRAS))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRRD', tRRD))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRFC', tRFC))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tWR', tWR))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tWTPr', tWTPr))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tRTPr', tRTPr))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'tFAW', tFAW))
-            hw_.append(('memory', 'DDR_%s' % ddr_channel, 'B2B', B2B))
 
 
 def parse_ipmi_sdr(hrdw, output):


### PR DESCRIPTION
The code to get ddr timings info is based on a tool that is not
maintained since years and currently does not work.