### PR TITLE
Add line to setup.cfg limiting to Python >=3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,12 @@
 [metadata]
 name = hardware
 summary = Hardware detection and classification utilities
-description-file =
+description_file =
     README.rst
 author = eNovance
-author-email = licensing@enovance.com
-home-page = https://github.com/redhat-cip/hardware
+author_email = licensing@enovance.com
+home_page = https://github.com/redhat-cip/hardware
+python_requires = >=3.6
 classifier =
     Topic :: System :: Hardware
     Intended Audience :: Information Technology


### PR DESCRIPTION
This adds "Requires-Python: >=3.6" to the PKG-INFO file, which will then
in turn be processed by PyPI and pip and prevent users on Python 2 from
being able to `pip install hardware`.