### PR TITLE
Security update set Babel min version to 2.9.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,5 @@
 
 stestr>=2.0.0 # Apache-2.0
 testtools>=0.9.34 # MIT
-Babel!=2.4.0,>=2.3.4 # BSD
+Babel>=2.9.1 # BSD
 


### PR DESCRIPTION
The update is due to https://nvd.nist.gov/vuln/detail/CVE-2021-42771