### PR TITLE
Fix regression in detect script

### DIFF
--- a/hardware/detect.py
+++ b/hardware/detect.py
@@ -84,8 +84,8 @@ def main():
     hrdw.extend(ipmi.get_ipmi_sdr())
     hrdw.extend(rtc.detect_rtc_clock())
     hrdw.extend(detect_utils.detect_auxv())
+    hrdw.extend(detect_utils.parse_dmesg())
 
-    detect_utils.parse_dmesg(hrdw)
     bios_hp.dump_hp_bios(hrdw)
 
     if args.benchmark:


### PR DESCRIPTION
The current unit tests are missing a check for the detect script.
Fixing breakage introduced by [1]

[1]https://github.com/redhat-cip/hardware/pull/181/commits/6da6ebb79955cc4717b1291199faeefd54265949