### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/docs-testing.yml
+++ b/.github/workflows/docs-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pep8-testing.yml
+++ b/.github/workflows/pep8-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description_file =
 author = eNovance
 author_email = licensing@enovance.com
 home_page = https://github.com/redhat-cip/hardware
-python_requires = >=3.6
+python_requires = >=3.7
 classifier =
     Topic :: System :: Hardware
     Intended Audience :: Information Technology
@@ -16,7 +16,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Python 3.6 support was deprecated and it's now removed.
The security support ended over 3 months ago.