### PR TITLE
Pin importlib-metadata under 5.0.0 for Python 3.7

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@
 stestr>=2.0.0 # Apache-2.0
 testtools>=2.2.0 # MIT
 Babel>=2.9.1 # BSD
+importlib-metadata>=1.1.0,<4.3;python_version<'3.8' # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps=
     hacking>=4.1.0,<5.0.0 # Apache-2.0
     flake8-import-order>=0.17.1 # LGPLv3
     pycodestyle>=2.0.0,<3.0.0 # MIT
+    importlib-metadata>=1.1.0,<4.3;python_version<'3.8' # Apache-2.0
 commands = flake8 {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
There is a compatibility issue between importlib-metadata 5.0.0 and
flake8 under Python 3.7 [1].

[1] https://github.com/python/importlib_metadata/issues/406
