### PR TITLE
fix: use `--random_generator=tausworthe64`

### DIFF
--- a/hardware/benchmark/disk.py
+++ b/hardware/benchmark/disk.py
@@ -71,7 +71,8 @@ def run_fio(hw_lst, disks_list, mode, io_size, time, rampup_time):
         os.remove(myfile)
     fio = ("fio --ioengine=libaio --invalidate=1 --ramp_time=%d --iodepth=32 "
            "--runtime=%d --time_based --direct=1 --output-format=json "
-           "--bs=%s --rw=%s" % (rampup_time, time, io_size, mode))
+           "--bs=%s --rw=%s --random_generator=tausworthe64" %
+           (rampup_time, time, io_size, mode))
 
     global_disk_list = ''
     for disk in disks_list:


### PR DESCRIPTION
If disks are large enough then FIO will write to stdout a warning that the default random generator is not sufficient. As this is written to stdout the subsequent attempt to parse the JSON will fail as it contains the warning before the JSON object.

To fix we can set the random generator to `tausworthe64` which will suppress the warning allow for the JSON to be parsed without error.

This issue has been noticed on disks around 64TB in size however could occur on smaller disks.

Fixes #201