### PR TITLE
Add pyproject.toml to support pip version 23.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["pbr>=6.0.0", "setuptools>=64.0.0"]
+build-backend = "pbr.build"
+


### PR DESCRIPTION
Version 23.1 of pip removes the "setup.py install" if no pyproject.toml is present.

This change adds a minimal pyproject.toml to use pbr to build wheels.

See https://pip.pypa.io/en/stable/news/#v23-1
and https://github.com/pypa/pip/issues/8368 for more info.