### PR TITLE
Update supported python versions

### DIFF
--- a/.github/workflows/docs-testing.yml
+++ b/.github/workflows/docs-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docs-testing.yml
+++ b/.github/workflows/docs-testing.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox

--- a/.github/workflows/pep8-testing.yml
+++ b/.github/workflows/pep8-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pep8-testing.yml
+++ b/.github/workflows/pep8-testing.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description_file =
 author = eNovance
 author_email = licensing@enovance.com
 home_page = https://github.com/redhat-cip/hardware
-python_requires = >=3.9
+python_requires = >=3.10
 classifier =
     Topic :: System :: Hardware
     Intended Audience :: Information Technology
@@ -16,10 +16,11 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ commands =
 
 [testenv:pep8]
 deps=
-    hacking~=6.1.0 # Apache-2.0
-    flake8-import-order~=0.18.0 # LGPLv3
+    hacking~=8.1.0 # Apache-2.0
+    flake8-import-order~=0.19.0 # LGPLv3
     pycodestyle>=2.0.0 # MIT
 commands = flake8 {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.0
-envlist = py39,py310,py311,py312,pep8,cover,docs
+envlist = py310,py311,py312,py313,py314,pep8,cover,docs
 skipsdist = True
 ignore_basepython_conflict=true
 


### PR DESCRIPTION
Python 3.9 reached its EOL. Also add Python 3.13 and 3.14 which have been available for some time.